### PR TITLE
[CLIPPER-107][CLIPPER-109] Implement JSON-formatted responses for query frontend

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -86,5 +86,7 @@ SpacesInSquareBrackets: false
 Standard:        Auto
 TabWidth:        8
 UseTab:          Never
+---
+Language:        Java
+BasedOnStyle:  Google
 ...
-

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ debug/
 .DS_STORE
 .idea/
 config.log
+target/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Sanitizers)
 # Include Boost as an imported target
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.60.0 REQUIRED COMPONENTS thread system chrono date_time atomic serialization)
+find_package(Boost 1.60.0 REQUIRED COMPONENTS thread system chrono date_time atomic)
 add_library(boost INTERFACE IMPORTED)
 set_property(TARGET boost PROPERTY
     INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,10 +7,10 @@ Vagrant.configure("2") do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", inline: <<-SHELL
-    apt-get update
-    apt-get upgrade
-    apt-get install -y cmake redis-server libhiredis-dev libev-dev libboost-all-dev libzmq3-dev g++ git
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get upgrade -y
+    sudo apt-get install -y cmake redis-server libhiredis-dev libev-dev libboost-all-dev libzmq3-dev g++ git
 
     cd /vagrant
     ./configure

--- a/bin/check_format.sh
+++ b/bin/check_format.sh
@@ -20,16 +20,32 @@ cd  $CLIPPER_ROOT
 set +e
 
 # Run clang-format
-num_violations="$(find ./src -not \( -path ./src/libs -prune \) -name '*pp' -print \
+num_cpp_violations="$(find ./src -not \( -path ./src/libs -prune \) -name '*pp' -print \
     | xargs clang-format -style=file -output-replacements-xml \
     | grep -c "<replacement ")"
 
-if [ $num_violations -eq 0 ]; then
-    echo "Passed Clang-Format check"
+if [ $num_cpp_violations -eq 0 ]; then
+    echo "Passed C++ Clang-Format check"
 else
-    echo "Found $num_violations Clang-Format violations"
+    echo "Found $num_cpp_violations C++ style violations."
+    echo "Run format_code.sh to fix."
     find ./src -not \( -path ./src/libs -prune \) -name '*pp' -print \
         | xargs clang-format -style=file
+    exit 1
+fi
+
+
+# Run clang-format
+num_java_violations="$(find . -name '*.java' -print \
+    | xargs clang-format -style=file -output-replacements-xml \
+    | grep -c "<replacement ")"
+
+if [ $num_java_violations -eq 0 ]; then
+    echo "Passed Java Clang-Format check"
+else
+    echo "Found $num_java_violations Java style violations"
+    echo "Run format_code.sh to fix."
+    find . -name '*.java' -print | xargs clang-format -style=file
     exit 1
 fi
 

--- a/bin/format_code.sh
+++ b/bin/format_code.sh
@@ -16,10 +16,15 @@ CLIPPER_ROOT=$DIR/..
 echo $CLIPPER_ROOT
 cd  $CLIPPER_ROOT
 
-# Run clang-format
+# Run clang-format on cpp/hpp files
 find ./src -not \( -path ./src/libs -prune \) -name '*pp' -print \
     | xargs clang-format -style=file -i
 
+# Run clang-format on Java files
+# find ./src -not \( -path ./src/libs -prune \) -name 'java' -print \
+#     | xargs clang-format -style=file -i
+
+find . -name '*.java' -print | xargs clang-format -style=file -i
 
 # Run Python formatter
 export PYTHONPATH=$CLIPPER_ROOT/bin/yapf

--- a/bin/run_unittests.sh
+++ b/bin/run_unittests.sh
@@ -57,6 +57,8 @@ fi
 
 randomize_redis_port
 
+set -e
+
 # start Redis on the test port if it's not already running
 redis-server --port $REDIS_PORT &> /dev/null &
 

--- a/containers/java/clipper-java-container/pom.xml
+++ b/containers/java/clipper-java-container/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>clipper.container.app</groupId>
+  <artifactId>clipper-java-container</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>clipper-java-container</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.zeromq</groupId>
+      <artifactId>jzmq</artifactId>
+       <version>3.1.0</version>
+    </dependency>
+  </dependencies>
+  <properties>
+	<maven.compiler.source>1.8</maven.compiler.source>
+   	<maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkMode>once</forkMode>
+          <workingDirectory>target</workingDirectory>
+          <argLine>-Djava.library.path=/usr/local/lib</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/Model.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/Model.java
@@ -1,0 +1,35 @@
+package clipper.container.app;
+
+import clipper.container.app.data.DataType;
+import clipper.container.app.data.DataVector;
+import clipper.container.app.data.FloatVector;
+
+abstract class Model<I extends DataVector> {
+  private String name;
+  private int version;
+  DataType inputType;
+
+  protected Model(String name, int version, DataType inputType) {
+    this.name = name;
+    this.version = version;
+    this.inputType = inputType;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public DataType getInputType() {
+    return inputType;
+  }
+
+  public DataType getOutputType() {
+    return DataType.Floats;
+  }
+
+  public abstract FloatVector predict(I inputVector);
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/ModelContainer.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/ModelContainer.java
@@ -1,0 +1,196 @@
+package clipper.container.app;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import clipper.container.app.data.*;
+import org.zeromq.ZMQ;
+
+class ModelContainer<I extends DataVector<?>> {
+  private static String CONNECTION_ADDRESS = "tcp://%s:%s";
+
+  private DataVectorParser<?, I> inputVectorParser;
+  private Thread servingThread;
+  private ByteBuffer responseBuffer;
+  private int responseBufferSize;
+
+  ModelContainer(DataVectorParser<?, I> inputVectorParser) {
+    this.inputVectorParser = inputVectorParser;
+  }
+
+  public void start(final Model<I> model, final String host, final int port)
+      throws UnknownHostException {
+    InetAddress address = InetAddress.getByName(host);
+    String ip = address.getHostAddress();
+    final ZMQ.Context context = ZMQ.context(1);
+
+    servingThread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        // Initialize ZMQ
+        ZMQ.Socket socket = context.socket(ZMQ.DEALER);
+        createConnection(socket, model, ip, port);
+        try {
+          serveModel(socket, model);
+        } catch (NoSuchFieldException | IllegalArgumentException e) {
+          e.printStackTrace();
+        }
+      }
+    });
+    servingThread.start();
+  }
+
+  public void stop() {
+    if (servingThread != null) {
+      servingThread.interrupt();
+      servingThread = null;
+    }
+  }
+
+  private void createConnection(ZMQ.Socket socket, Model<I> model, String ip, int port) {
+    String address = String.format(CONNECTION_ADDRESS, ip, port);
+    socket.connect(address);
+    socket.send("", ZMQ.SNDMORE);
+    socket.send(model.getName(), ZMQ.SNDMORE);
+    socket.send(String.valueOf(model.getVersion()), ZMQ.SNDMORE);
+    socket.send(String.valueOf(model.getInputType().getCode()));
+  }
+
+  private void serveModel(ZMQ.Socket socket, Model<I> model) throws NoSuchFieldException, IllegalArgumentException {
+    int inputHeaderBufferSize = 0;
+    int inputBufferSize = 0;
+    ByteBuffer inputHeaderBuffer = null;
+    ByteBuffer inputBuffer = null;
+    while (true) {
+      socket.recv();
+      PerformanceTimer.startTiming();
+      byte[] idMessage = socket.recv();
+      List<Long> parsedIdMessage = DataUtils.getUnsignedIntsFromBytes(idMessage);
+      if (parsedIdMessage.size() < 1) {
+        throw new NoSuchFieldException("Field \"message_id\" is missing from RPC message");
+      }
+      long msgId = parsedIdMessage.get(0);
+      System.out.println("Message ID: " + msgId);
+
+      byte[] requestHeaderMessage = socket.recv();
+      List<Integer> requestHeader = DataUtils.getSignedIntsFromBytes(requestHeaderMessage);
+      if (requestHeader.size() < 1) {
+        throw new NoSuchFieldException("Request header is missing from RPC message");
+      }
+      RequestType requestType = RequestType.fromCode(requestHeader.get(0));
+
+      if (requestType == RequestType.Predict) {
+        byte[] inputHeaderSizeMessage = socket.recv();
+        List<Long> parsedInputHeaderSizeMessage = DataUtils.getLongsFromBytes(inputHeaderSizeMessage);
+        if(parsedInputHeaderSizeMessage.size() < 1) {
+          throw new NoSuchFieldException("Input header size is missing from RPC predict request message");
+        }
+        int inputHeaderSize = (int) ((long) parsedInputHeaderSizeMessage.get(0));
+        if(inputHeaderBuffer == null || inputHeaderBufferSize < inputHeaderSize) {
+          inputHeaderBufferSize = inputHeaderSize * 2;
+          inputHeaderBuffer = ByteBuffer.allocateDirect(inputHeaderBufferSize);
+        }
+        inputHeaderBuffer.rewind();
+        inputHeaderBuffer.limit(inputHeaderBufferSize);
+        int inputHeaderBytesRead = socket.recvZeroCopy(inputHeaderBuffer, inputHeaderSize, -1);
+        inputHeaderBuffer.rewind();
+        inputHeaderBuffer.limit(inputHeaderBytesRead);
+
+        IntBuffer inputHeader = inputHeaderBuffer.slice().order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
+
+        byte[] inputContentSizeMessage = socket.recv();
+        List<Long> parsedInputContentSizeMessage = DataUtils.getLongsFromBytes(inputContentSizeMessage);
+        if(parsedInputContentSizeMessage.size() < 1) {
+          throw new NoSuchFieldException("Input content size is missing from RPC predict request message");
+        }
+
+        int inputContentSize = (int) ((long) parsedInputContentSizeMessage.get(0));
+        if(inputBufferSize < inputContentSize) {
+          inputBufferSize = inputContentSize * 2;
+          inputBuffer = ByteBuffer.allocateDirect(inputBufferSize);
+        }
+        inputBuffer.rewind();
+        inputBuffer.limit(inputBufferSize);
+        int inputBytesRead = socket.recvZeroCopy(inputBuffer, inputContentSize, -1);
+        inputBuffer.rewind();
+        inputBuffer.limit(inputBytesRead);
+
+        PerformanceTimer.logElapsed("Recv");
+
+        if (inputHeader.remaining() < 2) {
+          throw new NoSuchFieldException("RPC message input header is missing or is of insufficient size");
+        }
+
+        DataType inputType = DataType.fromCode(inputHeader.get());
+        int numInputs = inputHeader.get();
+        validateRequestInputType(model, inputType);
+        Iterator<I> dataVectors = inputVectorParser.parseDataVectors(inputBuffer.slice(), inputHeader.slice());
+
+        PerformanceTimer.logElapsed("Parse");
+
+        try {
+          handlePredictRequest(msgId, dataVectors, model, socket);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+
+        PerformanceTimer.logElapsed("Handle");
+        System.out.println(PerformanceTimer.getLog());
+      } else {
+        // Handle Feedback request
+      }
+    }
+  }
+
+  private void validateRequestInputType(Model<I> model, DataType inputType) throws IllegalArgumentException {
+    if (model.inputType != inputType) {
+      throw new IllegalArgumentException(
+              String.format(
+                      "RPC message has input of incorrect type \"%s\". Expected type: \"%s\"",
+                      inputType.toString(),
+                      model.inputType.toString()));
+    }
+  }
+
+  private void handlePredictRequest(
+      long msgId, Iterator<I> dataVectors, Model<I> model, ZMQ.Socket socket) throws IOException {
+    List<FloatVector> predictions = new ArrayList<>();
+    while(dataVectors.hasNext()) {
+      I dataVector = dataVectors.next();
+      FloatVector prediction = model.predict(dataVector);
+      predictions.add(prediction);
+    }
+    int outputLenBytes = 0;
+    for (FloatVector p : predictions) {
+      outputLenBytes += p.getData().remaining();
+    }
+    outputLenBytes = outputLenBytes * 4;
+    if(responseBuffer == null || responseBufferSize < outputLenBytes) {
+      responseBufferSize = outputLenBytes * 2;
+      responseBuffer = ByteBuffer.allocateDirect(responseBufferSize);
+      responseBuffer.order(ByteOrder.LITTLE_ENDIAN);
+    }
+    responseBuffer.rewind();
+    responseBuffer.limit(outputLenBytes);
+    for (FloatVector preds : predictions) {
+      while(preds.getData().hasRemaining()) {
+        responseBuffer.putFloat(preds.getData().get());
+      }
+    }
+    socket.send("", ZMQ.SNDMORE);
+    ByteBuffer b = ByteBuffer.allocate(8);
+    b.order(ByteOrder.LITTLE_ENDIAN);
+    b.putLong(msgId);
+    b.position(4);
+    byte[] msgIdByteArr = b.slice().array();
+    socket.send(msgIdByteArr, ZMQ.SNDMORE);
+    socket.sendZeroCopy(responseBuffer, responseBuffer.position(), 0);
+  }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/NoOpModel.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/NoOpModel.java
@@ -1,0 +1,20 @@
+package clipper.container.app;
+
+import clipper.container.app.data.DataType;
+import clipper.container.app.data.DataVector;
+import clipper.container.app.data.FloatVector;
+
+import java.nio.Buffer;
+import java.nio.FloatBuffer;
+
+public class NoOpModel<T extends DataVector<Buffer>> extends Model<T> {
+
+    public NoOpModel(String name, int version, DataType inputType) {
+        super(name, version, inputType);
+    }
+
+    @Override
+    public FloatVector predict(T inputVector) {
+        return new FloatVector(FloatBuffer.wrap(new float[] {(float) inputVector.getData().remaining()}));
+    }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/NoOpModel.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/NoOpModel.java
@@ -8,13 +8,13 @@ import java.nio.Buffer;
 import java.nio.FloatBuffer;
 
 public class NoOpModel<T extends DataVector<Buffer>> extends Model<T> {
+  public NoOpModel(String name, int version, DataType inputType) {
+    super(name, version, inputType);
+  }
 
-    public NoOpModel(String name, int version, DataType inputType) {
-        super(name, version, inputType);
-    }
-
-    @Override
-    public FloatVector predict(T inputVector) {
-        return new FloatVector(FloatBuffer.wrap(new float[] {(float) inputVector.getData().remaining()}));
-    }
+  @Override
+  public FloatVector predict(T inputVector) {
+    return new FloatVector(
+        FloatBuffer.wrap(new float[] {(float) inputVector.getData().remaining()}));
+  }
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/NoOpStringModel.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/NoOpStringModel.java
@@ -1,0 +1,19 @@
+package clipper.container.app;
+
+import clipper.container.app.data.DataType;
+import clipper.container.app.data.FloatVector;
+import clipper.container.app.data.SerializableString;
+
+import java.nio.FloatBuffer;
+
+public class NoOpStringModel extends Model<SerializableString> {
+
+    NoOpStringModel(String name, int version) {
+        super(name, version, DataType.Strings);
+    }
+
+    @Override
+    public FloatVector predict(SerializableString inputVector) {
+        return new FloatVector(FloatBuffer.wrap(new float[] {(float) inputVector.getData().length()}));
+    }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/NoOpStringModel.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/NoOpStringModel.java
@@ -7,13 +7,12 @@ import clipper.container.app.data.SerializableString;
 import java.nio.FloatBuffer;
 
 public class NoOpStringModel extends Model<SerializableString> {
+  NoOpStringModel(String name, int version) {
+    super(name, version, DataType.Strings);
+  }
 
-    NoOpStringModel(String name, int version) {
-        super(name, version, DataType.Strings);
-    }
-
-    @Override
-    public FloatVector predict(SerializableString inputVector) {
-        return new FloatVector(FloatBuffer.wrap(new float[] {(float) inputVector.getData().length()}));
-    }
+  @Override
+  public FloatVector predict(SerializableString inputVector) {
+    return new FloatVector(FloatBuffer.wrap(new float[] {(float) inputVector.getData().length()}));
+  }
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/PerformanceTimer.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/PerformanceTimer.java
@@ -1,0 +1,26 @@
+package clipper.container.app;
+
+public class PerformanceTimer {
+
+    static long lastLog;
+    static StringBuilder log;
+
+    public synchronized static void startTiming() {
+        log = new StringBuilder();
+        lastLog = System.currentTimeMillis();
+    }
+
+    public synchronized static void logElapsed(String tag) {
+        long currTime = System.currentTimeMillis();
+        String logMessage = tag + String.format(": %d", currTime - lastLog);
+        log.append(logMessage);
+        log.append("\n");
+        lastLog = currTime;
+    }
+
+    public static synchronized String getLog() {
+        return log.toString();
+    }
+
+
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/PerformanceTimer.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/PerformanceTimer.java
@@ -1,26 +1,23 @@
 package clipper.container.app;
 
 public class PerformanceTimer {
+  static long lastLog;
+  static StringBuilder log;
 
-    static long lastLog;
-    static StringBuilder log;
+  public synchronized static void startTiming() {
+    log = new StringBuilder();
+    lastLog = System.currentTimeMillis();
+  }
 
-    public synchronized static void startTiming() {
-        log = new StringBuilder();
-        lastLog = System.currentTimeMillis();
-    }
+  public synchronized static void logElapsed(String tag) {
+    long currTime = System.currentTimeMillis();
+    String logMessage = tag + String.format(": %d", currTime - lastLog);
+    log.append(logMessage);
+    log.append("\n");
+    lastLog = currTime;
+  }
 
-    public synchronized static void logElapsed(String tag) {
-        long currTime = System.currentTimeMillis();
-        String logMessage = tag + String.format(": %d", currTime - lastLog);
-        log.append(logMessage);
-        log.append("\n");
-        lastLog = currTime;
-    }
-
-    public static synchronized String getLog() {
-        return log.toString();
-    }
-
-
+  public static synchronized String getLog() {
+    return log.toString();
+  }
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/RequestType.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/RequestType.java
@@ -4,33 +4,32 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum RequestType {
+  Predict(0),
+  Feedback(1);
 
-    Predict(0),
-    Feedback(1);
+  private int code;
 
-    private int code;
+  RequestType(int code) {
+    this.code = code;
+  }
 
-    RequestType(int code) {
-        this.code = code;
+  public int getCode() {
+    return code;
+  }
+
+  private static final Map<Integer, RequestType> typeResolutionMap =
+      new HashMap<Integer, RequestType>();
+  static {
+    for (RequestType type : RequestType.values()) {
+      typeResolutionMap.put(type.getCode(), type);
     }
+  }
 
-    public int getCode() {
-        return code;
+  public static RequestType fromCode(int code) throws IllegalArgumentException {
+    if (!typeResolutionMap.containsKey(code)) {
+      throw new IllegalArgumentException(
+          String.format("Attempted to get request type from invalid code \"%d\"", code));
     }
-
-    private static final Map<Integer, RequestType> typeResolutionMap = new HashMap<Integer, RequestType>();
-    static {
-        for (RequestType type : RequestType.values()) {
-            typeResolutionMap.put(type.getCode(), type);
-        }
-    }
-
-    public static RequestType fromCode(int code) throws IllegalArgumentException {
-        if(!typeResolutionMap.containsKey(code)) {
-            throw new IllegalArgumentException(
-                    String.format("Attempted to get request type from invalid code \"%d\"", code));
-        }
-        return typeResolutionMap.get(code);
-    }
-
+    return typeResolutionMap.get(code);
+  }
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/RequestType.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/RequestType.java
@@ -1,0 +1,36 @@
+package clipper.container.app;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum RequestType {
+
+    Predict(0),
+    Feedback(1);
+
+    private int code;
+
+    RequestType(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    private static final Map<Integer, RequestType> typeResolutionMap = new HashMap<Integer, RequestType>();
+    static {
+        for (RequestType type : RequestType.values()) {
+            typeResolutionMap.put(type.getCode(), type);
+        }
+    }
+
+    public static RequestType fromCode(int code) throws IllegalArgumentException {
+        if(!typeResolutionMap.containsKey(code)) {
+            throw new IllegalArgumentException(
+                    String.format("Attempted to get request type from invalid code \"%d\"", code));
+        }
+        return typeResolutionMap.get(code);
+    }
+
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/RunContainer.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/RunContainer.java
@@ -1,0 +1,61 @@
+package clipper.container.app;
+
+import clipper.container.app.data.*;
+
+import java.net.UnknownHostException;
+
+public class RunContainer {
+
+    private static final int EXPECTED_NUM_ARGUMENTS = 5;
+
+    public static void main(String[] args) {
+        if(args.length < EXPECTED_NUM_ARGUMENTS) {
+            throw new IllegalArgumentException(
+                    "Arguments must be specified in order as: <model_name>, <model_version>, "
+                    + " <clipper_address>, <clipper_port>, <input_type>");
+        }
+        String modelName = args[0];
+        int modelVersion = Integer.valueOf(args[1]);
+        String clipperAddress = args[2];
+        int clipperPort = Integer.valueOf(args[3]);
+        DataType inputType = DataType.fromCode(Integer.valueOf(args[4]));
+
+        Model model;
+        if(inputType == DataType.Strings) {
+            model = new NoOpStringModel(modelName, modelVersion);
+        } else {
+            model = new NoOpModel(modelName, modelVersion, inputType);
+        }
+        runContainer(model, getParserForInputType(inputType), clipperAddress, clipperPort);
+    }
+
+    private static DataVectorParser getParserForInputType(DataType inputType) {
+        switch(inputType) {
+            case Bytes:
+                return new ByteVector.Parser();
+            case Ints:
+                return new IntVector.Parser();
+            case Floats:
+                return new FloatVector.Parser();
+            case Doubles:
+                return new DoubleVector.Parser();
+            case Strings:
+                return new SerializableString.Parser();
+            default:
+                return new ByteVector.Parser();
+        }
+    }
+
+    private static <I extends DataVector<?>> void runContainer(
+            Model<I> model, DataVectorParser<?, I> parser, String clipperAddress, int clipperPort) {
+        System.out.println("Starting...");
+        ModelContainer<I> modelContainer = new ModelContainer(parser);
+        try {
+            modelContainer.start(model, clipperAddress, clipperPort);
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+        while (true);
+    }
+
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/RunContainer.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/RunContainer.java
@@ -5,57 +5,56 @@ import clipper.container.app.data.*;
 import java.net.UnknownHostException;
 
 public class RunContainer {
+  private static final int EXPECTED_NUM_ARGUMENTS = 5;
 
-    private static final int EXPECTED_NUM_ARGUMENTS = 5;
-
-    public static void main(String[] args) {
-        if(args.length < EXPECTED_NUM_ARGUMENTS) {
-            throw new IllegalArgumentException(
-                    "Arguments must be specified in order as: <model_name>, <model_version>, "
-                    + " <clipper_address>, <clipper_port>, <input_type>");
-        }
-        String modelName = args[0];
-        int modelVersion = Integer.valueOf(args[1]);
-        String clipperAddress = args[2];
-        int clipperPort = Integer.valueOf(args[3]);
-        DataType inputType = DataType.fromCode(Integer.valueOf(args[4]));
-
-        Model model;
-        if(inputType == DataType.Strings) {
-            model = new NoOpStringModel(modelName, modelVersion);
-        } else {
-            model = new NoOpModel(modelName, modelVersion, inputType);
-        }
-        runContainer(model, getParserForInputType(inputType), clipperAddress, clipperPort);
+  public static void main(String[] args) {
+    if (args.length < EXPECTED_NUM_ARGUMENTS) {
+      throw new IllegalArgumentException(
+          "Arguments must be specified in order as: <model_name>, <model_version>, "
+          + " <clipper_address>, <clipper_port>, <input_type>");
     }
+    String modelName = args[0];
+    int modelVersion = Integer.valueOf(args[1]);
+    String clipperAddress = args[2];
+    int clipperPort = Integer.valueOf(args[3]);
+    DataType inputType = DataType.fromCode(Integer.valueOf(args[4]));
 
-    private static DataVectorParser getParserForInputType(DataType inputType) {
-        switch(inputType) {
-            case Bytes:
-                return new ByteVector.Parser();
-            case Ints:
-                return new IntVector.Parser();
-            case Floats:
-                return new FloatVector.Parser();
-            case Doubles:
-                return new DoubleVector.Parser();
-            case Strings:
-                return new SerializableString.Parser();
-            default:
-                return new ByteVector.Parser();
-        }
+    Model model;
+    if (inputType == DataType.Strings) {
+      model = new NoOpStringModel(modelName, modelVersion);
+    } else {
+      model = new NoOpModel(modelName, modelVersion, inputType);
     }
+    runContainer(model, getParserForInputType(inputType), clipperAddress, clipperPort);
+  }
 
-    private static <I extends DataVector<?>> void runContainer(
-            Model<I> model, DataVectorParser<?, I> parser, String clipperAddress, int clipperPort) {
-        System.out.println("Starting...");
-        ModelContainer<I> modelContainer = new ModelContainer(parser);
-        try {
-            modelContainer.start(model, clipperAddress, clipperPort);
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
-        }
-        while (true);
+  private static DataVectorParser getParserForInputType(DataType inputType) {
+    switch (inputType) {
+      case Bytes:
+        return new ByteVector.Parser();
+      case Ints:
+        return new IntVector.Parser();
+      case Floats:
+        return new FloatVector.Parser();
+      case Doubles:
+        return new DoubleVector.Parser();
+      case Strings:
+        return new SerializableString.Parser();
+      default:
+        return new ByteVector.Parser();
     }
+  }
 
+  private static <I extends DataVector<?>> void runContainer(
+      Model<I> model, DataVectorParser<?, I> parser, String clipperAddress, int clipperPort) {
+    System.out.println("Starting...");
+    ModelContainer<I> modelContainer = new ModelContainer(parser);
+    try {
+      modelContainer.start(model, clipperAddress, clipperPort);
+    } catch (UnknownHostException e) {
+      e.printStackTrace();
+    }
+    while (true)
+      ;
+  }
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/ByteVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/ByteVector.java
@@ -1,0 +1,47 @@
+package clipper.container.app.data;
+
+import java.nio.ByteBuffer;
+
+public class ByteVector extends DataVector<ByteBuffer> {
+
+  public ByteVector(ByteBuffer data) {
+    super(data);
+  }
+
+  public static class Parser extends DataVectorParser<ByteBuffer, ByteVector> {
+    @Override
+    ByteVector constructDataVector(ByteBuffer data) {
+      return new ByteVector(data);
+    }
+
+    @Override
+    DataBuffer<ByteBuffer> createDataBuffer() {
+      return new DataBuffer<ByteBuffer>() {
+
+        ByteBuffer buffer;
+        int bufferSize;
+
+        @Override
+        void init(ByteBuffer inputBuffer) {
+          this.buffer = inputBuffer;
+          this.bufferSize = buffer.remaining();
+        }
+
+        @Override
+        ByteBuffer get(int size) {
+          int outputLimit = buffer.position() + size;
+          buffer.limit(outputLimit);
+          ByteBuffer outputBuffer = buffer.slice();
+          buffer.position(outputLimit);
+          buffer.limit(bufferSize);
+          return outputBuffer;
+        }
+
+        @Override
+        ByteBuffer getAll() {
+          return buffer;
+        }
+      };
+    }
+  }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/ByteVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/ByteVector.java
@@ -3,7 +3,6 @@ package clipper.container.app.data;
 import java.nio.ByteBuffer;
 
 public class ByteVector extends DataVector<ByteBuffer> {
-
   public ByteVector(ByteBuffer data) {
     super(data);
   }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataBuffer.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataBuffer.java
@@ -3,7 +3,6 @@ package clipper.container.app.data;
 import java.nio.ByteBuffer;
 
 public abstract class DataBuffer<T> {
-
   abstract void init(ByteBuffer inputBuffer);
 
   abstract T get(int size);

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataBuffer.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataBuffer.java
@@ -1,0 +1,12 @@
+package clipper.container.app.data;
+
+import java.nio.ByteBuffer;
+
+public abstract class DataBuffer<T> {
+
+  abstract void init(ByteBuffer inputBuffer);
+
+  abstract T get(int size);
+
+  abstract T getAll();
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataType.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataType.java
@@ -1,0 +1,43 @@
+package clipper.container.app.data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum DataType {
+    Bytes(0, "bytes"),
+    Ints(1, "ints"),
+    Floats(2, "floats"),
+    Doubles(3, "doubles"),
+    Strings(4, "strings");
+
+    private int code;
+    private String name;
+
+    DataType(int code, String name) {
+        this.code = code;
+        this.name = name;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String toString() {
+        return name;
+    }
+
+    private static final Map<Integer, DataType> typeResolutionMap = new HashMap<Integer, DataType>();
+    static {
+        for (DataType type : DataType.values()) {
+            typeResolutionMap.put(type.getCode(), type);
+        }
+    }
+
+    public static DataType fromCode(int code) throws IllegalArgumentException {
+        if(!typeResolutionMap.containsKey(code)) {
+            throw new IllegalArgumentException(
+                    String.format("Attempted to get data type from invalid code \"%d\"", code));
+        }
+        return typeResolutionMap.get(code);
+    }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataType.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataType.java
@@ -4,40 +4,40 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum DataType {
-    Bytes(0, "bytes"),
-    Ints(1, "ints"),
-    Floats(2, "floats"),
-    Doubles(3, "doubles"),
-    Strings(4, "strings");
+  Bytes(0, "bytes"),
+  Ints(1, "ints"),
+  Floats(2, "floats"),
+  Doubles(3, "doubles"),
+  Strings(4, "strings");
 
-    private int code;
-    private String name;
+  private int code;
+  private String name;
 
-    DataType(int code, String name) {
-        this.code = code;
-        this.name = name;
+  DataType(int code, String name) {
+    this.code = code;
+    this.name = name;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  public String toString() {
+    return name;
+  }
+
+  private static final Map<Integer, DataType> typeResolutionMap = new HashMap<Integer, DataType>();
+  static {
+    for (DataType type : DataType.values()) {
+      typeResolutionMap.put(type.getCode(), type);
     }
+  }
 
-    public int getCode() {
-        return code;
+  public static DataType fromCode(int code) throws IllegalArgumentException {
+    if (!typeResolutionMap.containsKey(code)) {
+      throw new IllegalArgumentException(
+          String.format("Attempted to get data type from invalid code \"%d\"", code));
     }
-
-    public String toString() {
-        return name;
-    }
-
-    private static final Map<Integer, DataType> typeResolutionMap = new HashMap<Integer, DataType>();
-    static {
-        for (DataType type : DataType.values()) {
-            typeResolutionMap.put(type.getCode(), type);
-        }
-    }
-
-    public static DataType fromCode(int code) throws IllegalArgumentException {
-        if(!typeResolutionMap.containsKey(code)) {
-            throw new IllegalArgumentException(
-                    String.format("Attempted to get data type from invalid code \"%d\"", code));
-        }
-        return typeResolutionMap.get(code);
-    }
+    return typeResolutionMap.get(code);
+  }
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataUtils.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataUtils.java
@@ -8,98 +8,97 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public class DataUtils {
+  private static ByteBuffer getByteBuffer(byte[] bytes) {
+    ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+    return buffer;
+  }
 
-    private static ByteBuffer getByteBuffer(byte[] bytes) {
-        ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
-        return buffer;
+  public static byte[] getBytesFromInts(int[] data) {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 4);
+    for (int item : data) {
+      byteBuffer.putInt(item);
     }
+    return byteBuffer.array();
+  }
 
-    public static byte[] getBytesFromInts(int[] data) {
-        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 4);
-        for(int item : data) {
-            byteBuffer.putInt(item);
-        }
-        return byteBuffer.array();
+  public static byte[] getBytesFromLongs(long[] data) {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 8);
+    for (long item : data) {
+      byteBuffer.putLong(item);
     }
+    return byteBuffer.array();
+  }
 
-    public static byte[] getBytesFromLongs(long[] data) {
-        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 8);
-        for(long item : data) {
-            byteBuffer.putLong(item);
-        }
-        return byteBuffer.array();
+  public static byte[] getBytesFromFloats(float[] data) {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 4);
+    for (float item : data) {
+      byteBuffer.putFloat(item);
     }
+    return byteBuffer.array();
+  }
 
-    public static byte[] getBytesFromFloats(float[] data) {
-        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 4);
-        for(float item : data) {
-            byteBuffer.putFloat(item);
-        }
-        return byteBuffer.array();
+  public static byte[] getBytesFromDoubles(double[] data) {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 8);
+    for (double item : data) {
+      byteBuffer.putDouble(item);
     }
+    return byteBuffer.array();
+  }
 
-    public static byte[] getBytesFromDoubles(double[] data) {
-        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 8);
-        for(double item : data) {
-            byteBuffer.putDouble(item);
-        }
-        return byteBuffer.array();
+  private static <T> List<T> getTypeFromBytes(byte[] bytes, Function<ByteBuffer, T> func) {
+    List<T> parsedData = new ArrayList<>();
+    ByteBuffer byteBuffer = getByteBuffer(bytes);
+    while (byteBuffer.remaining() > 0) {
+      T item = func.apply(byteBuffer);
+      parsedData.add(item);
     }
+    return parsedData;
+  }
 
-    private static <T> List<T> getTypeFromBytes(byte[] bytes, Function<ByteBuffer, T> func) {
-        List<T> parsedData = new ArrayList<>();
-        ByteBuffer byteBuffer = getByteBuffer(bytes);
-        while (byteBuffer.remaining() > 0) {
-            T item = func.apply(byteBuffer);
-            parsedData.add(item);
-        }
-        return parsedData;
-    }
+  public static List<Long> getUnsignedIntsFromBytes(byte[] bytes) {
+    return getTypeFromBytes(bytes, new Function<ByteBuffer, Long>() {
+      @Override
+      public Long apply(ByteBuffer byteBuffer) {
+        int signedItem = byteBuffer.getInt();
+        long unsignedItem = Integer.toUnsignedLong(signedItem);
+        return unsignedItem;
+      }
+    });
+  }
 
-    public static List<Long> getUnsignedIntsFromBytes(byte[] bytes) {
-        return getTypeFromBytes(bytes, new Function<ByteBuffer, Long>() {
-            @Override
-            public Long apply(ByteBuffer byteBuffer) {
-                int signedItem = byteBuffer.getInt();
-                long unsignedItem = Integer.toUnsignedLong(signedItem);
-                return unsignedItem;
-            }
-        });
-    }
+  public static List<Integer> getSignedIntsFromBytes(byte[] bytes) {
+    return getTypeFromBytes(bytes, new Function<ByteBuffer, Integer>() {
+      @Override
+      public Integer apply(ByteBuffer byteBuffer) {
+        return byteBuffer.getInt();
+      }
+    });
+  }
 
-    public static List<Integer> getSignedIntsFromBytes(byte[] bytes) {
-        return getTypeFromBytes(bytes, new Function<ByteBuffer, Integer>() {
-            @Override
-            public Integer apply(ByteBuffer byteBuffer) {
-                return byteBuffer.getInt();
-            }
-        });
-    }
+  public static List<Long> getLongsFromBytes(byte[] bytes) {
+    return getTypeFromBytes(bytes, new Function<ByteBuffer, Long>() {
+      @Override
+      public Long apply(ByteBuffer byteBuffer) {
+        return byteBuffer.getLong();
+      }
+    });
+  }
 
-    public static List<Long> getLongsFromBytes(byte[] bytes) {
-        return getTypeFromBytes(bytes, new Function<ByteBuffer, Long>() {
-            @Override
-            public Long apply(ByteBuffer byteBuffer) {
-                return byteBuffer.getLong();
-            }
-        });
-    }
+  public static List<Float> getFloatsFromBytes(byte[] bytes) {
+    return getTypeFromBytes(bytes, new Function<ByteBuffer, Float>() {
+      @Override
+      public Float apply(ByteBuffer byteBuffer) {
+        return byteBuffer.getFloat();
+      }
+    });
+  }
 
-    public static List<Float> getFloatsFromBytes(byte[] bytes) {
-        return getTypeFromBytes(bytes, new Function<ByteBuffer, Float>() {
-            @Override
-            public Float apply(ByteBuffer byteBuffer) {
-                return byteBuffer.getFloat();
-            }
-        });
-    }
-
-    public static List<Double> getDoublesFromBytes(byte[] bytes) {
-        return getTypeFromBytes(bytes, new Function<ByteBuffer, Double>() {
-            @Override
-            public Double apply(ByteBuffer byteBuffer) {
-                return byteBuffer.getDouble();
-            }
-        });
-    }
+  public static List<Double> getDoublesFromBytes(byte[] bytes) {
+    return getTypeFromBytes(bytes, new Function<ByteBuffer, Double>() {
+      @Override
+      public Double apply(ByteBuffer byteBuffer) {
+        return byteBuffer.getDouble();
+      }
+    });
+  }
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataUtils.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataUtils.java
@@ -1,0 +1,105 @@
+package clipper.container.app.data;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class DataUtils {
+
+    private static ByteBuffer getByteBuffer(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        return buffer;
+    }
+
+    public static byte[] getBytesFromInts(int[] data) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 4);
+        for(int item : data) {
+            byteBuffer.putInt(item);
+        }
+        return byteBuffer.array();
+    }
+
+    public static byte[] getBytesFromLongs(long[] data) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 8);
+        for(long item : data) {
+            byteBuffer.putLong(item);
+        }
+        return byteBuffer.array();
+    }
+
+    public static byte[] getBytesFromFloats(float[] data) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 4);
+        for(float item : data) {
+            byteBuffer.putFloat(item);
+        }
+        return byteBuffer.array();
+    }
+
+    public static byte[] getBytesFromDoubles(double[] data) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 8);
+        for(double item : data) {
+            byteBuffer.putDouble(item);
+        }
+        return byteBuffer.array();
+    }
+
+    private static <T> List<T> getTypeFromBytes(byte[] bytes, Function<ByteBuffer, T> func) {
+        List<T> parsedData = new ArrayList<>();
+        ByteBuffer byteBuffer = getByteBuffer(bytes);
+        while (byteBuffer.remaining() > 0) {
+            T item = func.apply(byteBuffer);
+            parsedData.add(item);
+        }
+        return parsedData;
+    }
+
+    public static List<Long> getUnsignedIntsFromBytes(byte[] bytes) {
+        return getTypeFromBytes(bytes, new Function<ByteBuffer, Long>() {
+            @Override
+            public Long apply(ByteBuffer byteBuffer) {
+                int signedItem = byteBuffer.getInt();
+                long unsignedItem = Integer.toUnsignedLong(signedItem);
+                return unsignedItem;
+            }
+        });
+    }
+
+    public static List<Integer> getSignedIntsFromBytes(byte[] bytes) {
+        return getTypeFromBytes(bytes, new Function<ByteBuffer, Integer>() {
+            @Override
+            public Integer apply(ByteBuffer byteBuffer) {
+                return byteBuffer.getInt();
+            }
+        });
+    }
+
+    public static List<Long> getLongsFromBytes(byte[] bytes) {
+        return getTypeFromBytes(bytes, new Function<ByteBuffer, Long>() {
+            @Override
+            public Long apply(ByteBuffer byteBuffer) {
+                return byteBuffer.getLong();
+            }
+        });
+    }
+
+    public static List<Float> getFloatsFromBytes(byte[] bytes) {
+        return getTypeFromBytes(bytes, new Function<ByteBuffer, Float>() {
+            @Override
+            public Float apply(ByteBuffer byteBuffer) {
+                return byteBuffer.getFloat();
+            }
+        });
+    }
+
+    public static List<Double> getDoublesFromBytes(byte[] bytes) {
+        return getTypeFromBytes(bytes, new Function<ByteBuffer, Double>() {
+            @Override
+            public Double apply(ByteBuffer byteBuffer) {
+                return byteBuffer.getDouble();
+            }
+        });
+    }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataVector.java
@@ -1,0 +1,15 @@
+package clipper.container.app.data;
+
+public abstract class DataVector<T> {
+
+    T data;
+
+    DataVector(T data) {
+        this.data = data;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataVector.java
@@ -1,15 +1,13 @@
 package clipper.container.app.data;
 
 public abstract class DataVector<T> {
+  T data;
 
-    T data;
+  DataVector(T data) {
+    this.data = data;
+  }
 
-    DataVector(T data) {
-        this.data = data;
-    }
-
-    public T getData() {
-        return data;
-    }
-
+  public T getData() {
+    return data;
+  }
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataVectorParser.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataVectorParser.java
@@ -1,0 +1,70 @@
+package clipper.container.app.data;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.util.Iterator;
+
+public abstract class DataVectorParser<U, T extends DataVector<U>> {
+
+  private DataBuffer<U> dataBuffer;
+
+  abstract T constructDataVector(U data);
+
+  abstract DataBuffer<U> createDataBuffer();
+
+  private DataBuffer<U> getDataBuffer() {
+    if(dataBuffer == null) {
+      dataBuffer = createDataBuffer();
+    }
+    return dataBuffer;
+  }
+
+  public Iterator<T> parseDataVectors(ByteBuffer byteBuffer, IntBuffer splits) {
+    return new DataVectorIterator(byteBuffer, splits);
+  }
+
+  class DataVectorIterator implements Iterator<T> {
+
+    private IntBuffer splits;
+    private ByteBuffer buffer;
+    private int currentSplitIndex;
+    private int prevSplit;
+
+    DataVectorIterator(ByteBuffer buffer, IntBuffer splits) {
+      this.splits = splits;
+      this.buffer = buffer;
+      this.currentSplitIndex = 0;
+      this.prevSplit = 0;
+      getDataBuffer().init(buffer);
+    }
+
+    @Override
+    public boolean hasNext() {
+      return (buffer != null)
+              && (splits != null)
+              && (currentSplitIndex >= 0)
+              // If the split index is equivalent to the length
+              // of the splits list, data must be processed
+              // from the last split through the buffer's end
+              && (currentSplitIndex <= splits.remaining());
+    }
+
+    @Override
+    public T next() {
+      DataBuffer<U> dataBuffer = getDataBuffer();
+      U parsedArray;
+      T dataVector;
+      if(currentSplitIndex < splits.remaining()) {
+        int currSplit = splits.get(currentSplitIndex);
+        parsedArray = dataBuffer.get(currSplit - prevSplit);
+        prevSplit = currSplit;
+      } else {
+        parsedArray = dataBuffer.getAll();
+      }
+      dataVector = constructDataVector(parsedArray);
+      currentSplitIndex++;
+      return dataVector;
+    }
+  }
+
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataVectorParser.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DataVectorParser.java
@@ -5,7 +5,6 @@ import java.nio.IntBuffer;
 import java.util.Iterator;
 
 public abstract class DataVectorParser<U, T extends DataVector<U>> {
-
   private DataBuffer<U> dataBuffer;
 
   abstract T constructDataVector(U data);
@@ -13,7 +12,7 @@ public abstract class DataVectorParser<U, T extends DataVector<U>> {
   abstract DataBuffer<U> createDataBuffer();
 
   private DataBuffer<U> getDataBuffer() {
-    if(dataBuffer == null) {
+    if (dataBuffer == null) {
       dataBuffer = createDataBuffer();
     }
     return dataBuffer;
@@ -24,7 +23,6 @@ public abstract class DataVectorParser<U, T extends DataVector<U>> {
   }
 
   class DataVectorIterator implements Iterator<T> {
-
     private IntBuffer splits;
     private ByteBuffer buffer;
     private int currentSplitIndex;
@@ -40,13 +38,11 @@ public abstract class DataVectorParser<U, T extends DataVector<U>> {
 
     @Override
     public boolean hasNext() {
-      return (buffer != null)
-              && (splits != null)
-              && (currentSplitIndex >= 0)
-              // If the split index is equivalent to the length
-              // of the splits list, data must be processed
-              // from the last split through the buffer's end
-              && (currentSplitIndex <= splits.remaining());
+      return (buffer != null) && (splits != null) && (currentSplitIndex >= 0)
+          // If the split index is equivalent to the length
+          // of the splits list, data must be processed
+          // from the last split through the buffer's end
+          && (currentSplitIndex <= splits.remaining());
     }
 
     @Override
@@ -54,7 +50,7 @@ public abstract class DataVectorParser<U, T extends DataVector<U>> {
       DataBuffer<U> dataBuffer = getDataBuffer();
       U parsedArray;
       T dataVector;
-      if(currentSplitIndex < splits.remaining()) {
+      if (currentSplitIndex < splits.remaining()) {
         int currSplit = splits.get(currentSplitIndex);
         parsedArray = dataBuffer.get(currSplit - prevSplit);
         prevSplit = currSplit;
@@ -66,5 +62,4 @@ public abstract class DataVectorParser<U, T extends DataVector<U>> {
       return dataVector;
     }
   }
-
 }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DoubleVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DoubleVector.java
@@ -5,7 +5,6 @@ import java.nio.DoubleBuffer;
 import java.nio.ByteOrder;
 
 public class DoubleVector extends DataVector<DoubleBuffer> {
-
   public DoubleVector(DoubleBuffer data) {
     super(data);
   }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DoubleVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/DoubleVector.java
@@ -1,0 +1,50 @@
+package clipper.container.app.data;
+
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.ByteOrder;
+
+public class DoubleVector extends DataVector<DoubleBuffer> {
+
+  public DoubleVector(DoubleBuffer data) {
+    super(data);
+  }
+
+  public static class Parser extends DataVectorParser<DoubleBuffer, DoubleVector> {
+    @Override
+    DoubleVector constructDataVector(DoubleBuffer data) {
+      return new DoubleVector(data);
+    }
+
+    @Override
+    DataBuffer<DoubleBuffer> createDataBuffer() {
+      return new DataBuffer<DoubleBuffer>() {
+
+        DoubleBuffer buffer;
+        int bufferSize;
+
+        @Override
+        void init(ByteBuffer inputBuffer) {
+          inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+          this.buffer = inputBuffer.asDoubleBuffer();
+          this.bufferSize = buffer.remaining();
+        }
+
+        @Override
+        DoubleBuffer get(int size) {
+          int outputLimit = buffer.position() + size;
+          buffer.limit(outputLimit);
+          DoubleBuffer outputBuffer = buffer.slice();
+          buffer.position(outputLimit);
+          buffer.limit(bufferSize);
+          return outputBuffer;
+        }
+
+        @Override
+        DoubleBuffer getAll() {
+          return buffer;
+        }
+      };
+    }
+  }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/FloatVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/FloatVector.java
@@ -1,0 +1,50 @@
+package clipper.container.app.data;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.ByteOrder;
+
+public class FloatVector extends DataVector<FloatBuffer> {
+
+  public FloatVector(FloatBuffer data) {
+    super(data);
+  }
+
+  public static class Parser extends DataVectorParser<FloatBuffer, FloatVector> {
+    @Override
+    FloatVector constructDataVector(FloatBuffer data) {
+      return new FloatVector(data);
+    }
+
+    @Override
+    DataBuffer<FloatBuffer> createDataBuffer() {
+      return new DataBuffer<FloatBuffer>() {
+
+        FloatBuffer buffer;
+        int bufferSize;
+
+        @Override
+        void init(ByteBuffer inputBuffer) {
+          inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+          this.buffer = inputBuffer.asFloatBuffer();
+          this.bufferSize = buffer.remaining();
+        }
+
+        @Override
+        FloatBuffer get(int size) {
+          int outputLimit = buffer.position() + size;
+          buffer.limit(outputLimit);
+          FloatBuffer outputBuffer = buffer.slice();
+          buffer.position(outputLimit);
+          buffer.limit(bufferSize);
+          return outputBuffer;
+        }
+
+        @Override
+        FloatBuffer getAll() {
+          return buffer;
+        }
+      };
+    }
+  }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/FloatVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/FloatVector.java
@@ -5,7 +5,6 @@ import java.nio.FloatBuffer;
 import java.nio.ByteOrder;
 
 public class FloatVector extends DataVector<FloatBuffer> {
-
   public FloatVector(FloatBuffer data) {
     super(data);
   }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/IntVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/IntVector.java
@@ -5,7 +5,6 @@ import java.nio.IntBuffer;
 import java.nio.ByteOrder;
 
 public class IntVector extends DataVector<IntBuffer> {
-
   public IntVector(IntBuffer data) {
     super(data);
   }

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/IntVector.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/IntVector.java
@@ -1,0 +1,50 @@
+package clipper.container.app.data;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.ByteOrder;
+
+public class IntVector extends DataVector<IntBuffer> {
+
+  public IntVector(IntBuffer data) {
+    super(data);
+  }
+
+  public static class Parser extends DataVectorParser<IntBuffer, IntVector> {
+    @Override
+    IntVector constructDataVector(IntBuffer data) {
+      return new IntVector(data);
+    }
+
+    @Override
+    DataBuffer<IntBuffer> createDataBuffer() {
+      return new DataBuffer<IntBuffer>() {
+
+        IntBuffer buffer;
+        int bufferSize;
+
+        @Override
+        void init(ByteBuffer inputBuffer) {
+          inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
+          this.buffer = inputBuffer.asIntBuffer();
+          this.bufferSize = buffer.remaining();
+        }
+
+        @Override
+        IntBuffer get(int size) {
+          int outputLimit = buffer.position() + size;
+          buffer.limit(outputLimit);
+          IntBuffer outputBuffer = buffer.slice();
+          buffer.position(outputLimit);
+          buffer.limit(bufferSize);
+          return outputBuffer;
+        }
+
+        @Override
+        IntBuffer getAll() {
+          return buffer;
+        }
+      };
+    }
+  }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/SerializableString.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/SerializableString.java
@@ -1,0 +1,58 @@
+package clipper.container.app.data;
+
+import sun.nio.cs.US_ASCII;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.CharBuffer;
+import java.nio.IntBuffer;
+import java.nio.charset.Charset;
+import java.util.Iterator;
+
+public class SerializableString extends DataVector<String> {
+
+  public SerializableString(String data) {
+    super(data);
+  }
+
+  public static class Parser extends DataVectorParser<String, SerializableString> {
+    @Override
+    SerializableString constructDataVector(String data) {
+      return null;
+    }
+
+    @Override
+    DataBuffer<String> createDataBuffer() {
+      return null;
+    }
+
+    @Override
+    public Iterator<SerializableString> parseDataVectors(ByteBuffer byteBuffer, IntBuffer splits) {
+      byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+      Charset asciiCharSet = US_ASCII.defaultCharset();
+      CharBuffer iterBuffer = asciiCharSet.decode(byteBuffer);
+      CharBuffer copyBuffer = iterBuffer.duplicate();
+
+      return new Iterator<SerializableString>() {
+
+        @Override
+        public boolean hasNext() {
+          return iterBuffer.hasRemaining();
+        }
+
+        @Override
+        public SerializableString next() {
+          int stringLength = 0;
+          while(iterBuffer.get() != '\0') {
+            stringLength++;
+          }
+          char[] stringChars = new char[stringLength];
+          copyBuffer.get(stringChars, 0, stringLength);
+          copyBuffer.get();
+          String stringData = new String(stringChars);
+          return new SerializableString(stringData);
+        }
+      };
+    }
+  }
+}

--- a/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/SerializableString.java
+++ b/containers/java/clipper-java-container/src/main/java/clipper/container/app/data/SerializableString.java
@@ -10,7 +10,6 @@ import java.nio.charset.Charset;
 import java.util.Iterator;
 
 public class SerializableString extends DataVector<String> {
-
   public SerializableString(String data) {
     super(data);
   }
@@ -43,7 +42,7 @@ public class SerializableString extends DataVector<String> {
         @Override
         public SerializableString next() {
           int stringLength = 0;
-          while(iterBuffer.get() != '\0') {
+          while (iterBuffer.get() != '\0') {
             stringLength++;
           }
           char[] stringChars = new char[stringLength];

--- a/containers/java/clipper-java-container/src/test/java/clipper/container/app/ContainerTest.java
+++ b/containers/java/clipper-java-container/src/test/java/clipper/container/app/ContainerTest.java
@@ -1,0 +1,28 @@
+package clipper.container.app;
+
+import java.net.UnknownHostException;
+
+import clipper.container.app.data.*;
+import org.junit.Test;
+
+public class ContainerTest {
+  @Test
+  public void TestContainer() {
+    NoOpModel model = new NoOpModel("test", 1, DataType.Doubles);
+    runContainer(model, new DoubleVector.Parser());
+//    NoOpStringModel model = new NoOpStringModel("test", 1);
+//    runContainer(model, new SerializableString.Parser());
+  }
+
+  private <I extends DataVector<?>> void runContainer(
+          Model<I> model, DataVectorParser<?, I> parser) {
+    System.out.println("Starting...");
+    ModelContainer<I> modelContainer = new ModelContainer(parser);
+    try {
+      modelContainer.start(model, "127.0.0.1", 7000);
+    } catch (UnknownHostException e) {
+      e.printStackTrace();
+    }
+    while (true);
+  }
+}

--- a/containers/java/clipper-java-container/src/test/java/clipper/container/app/ContainerTest.java
+++ b/containers/java/clipper-java-container/src/test/java/clipper/container/app/ContainerTest.java
@@ -10,12 +10,12 @@ public class ContainerTest {
   public void TestContainer() {
     NoOpModel model = new NoOpModel("test", 1, DataType.Doubles);
     runContainer(model, new DoubleVector.Parser());
-//    NoOpStringModel model = new NoOpStringModel("test", 1);
-//    runContainer(model, new SerializableString.Parser());
+    //    NoOpStringModel model = new NoOpStringModel("test", 1);
+    //    runContainer(model, new SerializableString.Parser());
   }
 
   private <I extends DataVector<?>> void runContainer(
-          Model<I> model, DataVectorParser<?, I> parser) {
+      Model<I> model, DataVectorParser<?, I> parser) {
     System.out.println("Starting...");
     ModelContainer<I> modelContainer = new ModelContainer(parser);
     try {
@@ -23,6 +23,7 @@ public class ContainerTest {
     } catch (UnknownHostException e) {
       e.printStackTrace();
     }
-    while (true);
+    while (true)
+      ;
   }
 }

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -241,7 +241,7 @@ class Clipper:
 
     def register_application(self,
                              name,
-                             candidate_models,
+                             model,
                              input_type,
                              selection_policy,
                              slo_micros=20000):
@@ -251,14 +251,11 @@ class Clipper:
         ----------
         name : str
             The name of the application.
-        candidate_models : list of dict
-            The list of models this application will attempt to query.
-            Each candidate model is defined as a dict with keys `model_name`
+        model : dict
+            The model this application will query.
+            The model is defined as a dict with keys `model_name`
             and `model_version`. Example::
-                candidate_models = [
-                    {"model_name": "my_model", "model_version": 1},
-                    {"model_name": "other_model", "model_version": 1},
-                ]
+                model = {"model_name": "my_model", "model_version": 1}
         input_type : str
             One of "integers", "floats", "doubles", "bytes", or "strings".
         selection_policy : str
@@ -271,7 +268,7 @@ class Clipper:
         url = "http://%s:1338/admin/add_app" % self.host
         req_json = json.dumps({
             "name": name,
-            "candidate_models": candidate_models,
+            "candidate_models": list(model),
             "input_type": input_type,
             "selection_policy": selection_policy,
             "latency_slo_micros": slo_micros

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -243,7 +243,7 @@ class Clipper:
                              name,
                              model,
                              input_type,
-                             selection_policy,
+                             default_output,
                              slo_micros=20000):
         """Register a new Clipper application.
 
@@ -258,9 +258,9 @@ class Clipper:
                 model = {"model_name": "my_model", "model_version": 1}
         input_type : str
             One of "integers", "floats", "doubles", "bytes", or "strings".
-        selection_policy : str
-            The name of the model selection policy to be used for the
-            application.
+        default_output : float
+            The default prediction to use if the model does not return a prediction
+            by the end of the latency objective.
         slo_micros : int, optional
             The query latency objective for the application in microseconds.
             Default is 20,000 (20 ms).
@@ -270,7 +270,7 @@ class Clipper:
             "name": name,
             "candidate_models": list(model),
             "input_type": input_type,
-            "selection_policy": selection_policy,
+            "default_output": default_output,
             "latency_slo_micros": slo_micros
         })
         headers = {'Content-type': 'application/json'}

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -153,10 +153,16 @@ class Clipper:
             return run(*args, **kwargs)
 
     def _execute_local(self, *args, **kwargs):
+        # local is not currently capable of simultaneously printing and
+        # capturing output, as run/sudo do. The capture kwarg allows you to
+        # switch between printing and capturing as necessary, and defaults to
+        # False. In this case, we need to capture the output and return it.
+        if "capture" not in kwargs:
+            kwargs["capture"] = True
         # fabric.local() does not accept the "warn_only"
         # key word argument, so we must remove it before
         # calling
-        if "warn_only" in kwargs.keys():
+        if "warn_only" in kwargs:
             del kwargs["warn_only"]
             # Forces execution to continue in the face of an error,
             # just like warn_only=True

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -68,6 +68,8 @@ DOCKER_COMPOSE_DICT = {
 
 LOCAL_HOST_NAMES = ["local", "localhost", "127.0.0.1"]
 
+EXTERNALLY_MANAGED_MODEL = "EXTERNAL"
+
 
 class Clipper:
     """
@@ -353,6 +355,24 @@ class Clipper:
         r = requests.post(url, headers=headers, data=req_json)
         return r.text
 
+    def register_external_model(self, name, version, labels, input_type):
+        """Registers a model with Clipper without deploying it in any containers.
+
+        Parameters
+        ----------
+        name : str
+            The name to assign this model.
+        version : int
+            The version to assign this model.
+        labels : list of str
+            A set of strings annotating the model
+        input_type : str
+            One of "integers", "floats", "doubles", "bytes", or "strings".
+        """
+        return self._publish_new_model(name, version, labels, input_type,
+                                       EXTERNALLY_MANAGED_MODEL,
+                                       EXTERNALLY_MANAGED_MODEL)
+
     def deploy_model(self,
                      name,
                      version,
@@ -361,7 +381,7 @@ class Clipper:
                      labels,
                      input_type,
                      num_containers=1):
-        """Add a model to Clipper.
+        """Registers a model with Clipper and deploys instances of it in containers.
 
         Parameters
         ----------

--- a/src/benchmarks/CMakeLists.txt
+++ b/src/benchmarks/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
 add_executable(end_to_end_bench src/end_to_end_bench.cpp)
 
-target_link_libraries(end_to_end_bench clipper boost)
+target_link_libraries(end_to_end_bench clipper boost cxxopts)
 
 
 ##################################

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -117,9 +117,10 @@ class RequestHandler {
             InputType input_type =
                 clipper::parse_input_type(app_info["input_type"]);
             std::string policy = app_info["policy"];
+            std::string default_output = app_info["default_output"];
             int latency_slo_micros = std::stoi(app_info["latency_slo_micros"]);
             add_application(name, candidate_models, input_type, policy,
-                            latency_slo_micros);
+                            default_output, latency_slo_micros);
           }
         });
   }
@@ -131,7 +132,21 @@ class RequestHandler {
 
   void add_application(std::string name, std::vector<VersionedModelId> models,
                        InputType input_type, std::string policy,
-                       long latency_slo_micros) {
+                       std::string default_output, long latency_slo_micros) {
+    // TODO: QueryProcessor should handle this. We need to decide how the
+    // default output fits into the generic selection policy API. Do all
+    // selection policies have a default output?
+    //
+    // Initialize selection state for this application
+    if (policy == "DefaultOutputSelectionPolicy") {
+      clipper::DefaultOutputSelectionPolicy p;
+      clipper::Output parsed_default_output(std::stod(default_output), {});
+      auto init_state = p.init_state(parsed_default_output);
+      clipper::StateKey state_key{name, clipper::DEFAULT_USER_ID, 0};
+      query_processor_.get_state_table()->put(state_key,
+                                              p.serialize(init_state));
+    }
+
     auto predict_fn = [this, name, input_type, policy, latency_slo_micros,
                        models](std::shared_ptr<HttpServer::Response> response,
                                std::shared_ptr<HttpServer::Request> request) {

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -163,6 +163,7 @@ class RequestHandler {
           std::stringstream ss;
           ss << "qid:" << r.query_id_ << ", predict:" << r.output_.y_hat_;
           rapidjson::Document json_response;
+          json_response.SetObject();
           clipper::json::add_long(json_response, RESPONSE_KEY_QUERY_ID, r.query_id_);
           clipper::json::add_double(json_response, RESPONSE_KEY_OUTPUT, r.output_.y_hat_);
           clipper::json::add_bool(json_response, RESPONSE_KEY_USED_DEFAULT, r.output_is_default_);

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -34,8 +34,9 @@ namespace query_frontend {
 const std::string LOGGING_TAG_QUERY_FRONTEND = "QUERYFRONTEND";
 const std::string GET_METRICS = "^/metrics$";
 
-const std::string RESPONSE_KEY_OUTPUT = "output";
-const std::string RESPONSE_KEY_USED_DEFAULT = "default";
+const char* RESPONSE_KEY_QUERY_ID = "query_id";
+const char* RESPONSE_KEY_OUTPUT = "output";
+const char* RESPONSE_KEY_USED_DEFAULT = "default";
 
 const std::string PREDICTION_JSON_SCHEMA = R"(
   {
@@ -161,12 +162,13 @@ class RequestHandler {
           Response r = f.get();
           std::stringstream ss;
           ss << "qid:" << r.query_id_ << ", predict:" << r.output_.y_hat_;
-
           rapidjson::Document json_response;
+          clipper::json::add_long(json_response, RESPONSE_KEY_QUERY_ID, r.query_id_);
           clipper::json::add_double(json_response, RESPONSE_KEY_OUTPUT, r.output_.y_hat_);
-          clipper::json::
+          clipper::json::add_bool(json_response, RESPONSE_KEY_USED_DEFAULT, r.output_is_default_);
 
-          std::string content = ss.str();
+          //std::string content = ss.str();
+          std::string content = clipper::json::to_json_string(json_response);
           respond_http(content, "200 OK", response);
         });
       } catch (const json_parse_error& e) {

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -37,6 +37,11 @@ const std::string GET_METRICS = "^/metrics$";
 const char* RESPONSE_KEY_QUERY_ID = "query_id";
 const char* RESPONSE_KEY_OUTPUT = "output";
 const char* RESPONSE_KEY_USED_DEFAULT = "default";
+const char* ERROR_RESPONSE_KEY_ERROR = "error";
+const char* ERROR_RESPONSE_KEY_CAUSE = "cause";
+
+const std::string PREDICTION_ERROR_NAME_JSON = "Json Error";
+const std::string PREDICTION_ERROR_NAME_QUERY_PROCESSING = "Query Processing Error";
 
 const std::string PREDICTION_JSON_SCHEMA = R"(
   {
@@ -160,28 +165,34 @@ class RequestHandler {
                                       policy, latency_slo_micros, input_type);
         prediction.then([response](boost::future<Response> f) {
           Response r = f.get();
-          std::stringstream ss;
-          ss << "qid:" << r.query_id_ << ", predict:" << r.output_.y_hat_;
           rapidjson::Document json_response;
           json_response.SetObject();
           clipper::json::add_long(json_response, RESPONSE_KEY_QUERY_ID, r.query_id_);
           clipper::json::add_double(json_response, RESPONSE_KEY_OUTPUT, r.output_.y_hat_);
           clipper::json::add_bool(json_response, RESPONSE_KEY_USED_DEFAULT, r.output_is_default_);
-
-          //std::string content = ss.str();
           std::string content = clipper::json::to_json_string(json_response);
           respond_http(content, "200 OK", response);
         });
       } catch (const json_parse_error& e) {
         std::string error_msg =
             json_error_msg(e.what(), PREDICTION_JSON_SCHEMA);
-        respond_http(error_msg, "400 Bad Request", response);
+        std::string json_error_response = get_prediction_error_response(PREDICTION_ERROR_NAME_JSON, error_msg);
+        respond_http(json_error_response, "400 Bad Request", response);
       } catch (const json_semantic_error& e) {
         std::string error_msg =
             json_error_msg(e.what(), PREDICTION_JSON_SCHEMA);
-        respond_http(error_msg, "400 Bad Request", response);
+        std::string json_error_response = get_prediction_error_response(PREDICTION_ERROR_NAME_JSON, error_msg);
+        respond_http(json_error_response, "400 Bad Request", response);
       } catch (const std::invalid_argument& e) {
-        respond_http(e.what(), "400 Bad Request", response);
+        // This invalid argument exception is most likely the propagation of an exception thrown
+        // when Rapidjson attempts to parse an invalid json schema
+        std::string json_error_response = get_prediction_error_response(PREDICTION_ERROR_NAME_JSON, e.what());
+        respond_http(json_error_response, "400 Bad Request", response);
+      } catch (const clipper::PredictError& e) {
+        std::string error_msg = e.what();
+        std::string json_error_response =
+            get_prediction_error_response(PREDICTION_ERROR_NAME_QUERY_PROCESSING, error_msg);
+        respond_http(json_error_response, "400 Bad Request", response);
       }
     };
     std::string predict_endpoint = "^/" + name + "/predict$";
@@ -212,6 +223,14 @@ class RequestHandler {
     };
     std::string update_endpoint = "^/" + name + "/update$";
     server_.add_endpoint(update_endpoint, "POST", update_fn);
+  }
+
+  const std::string get_prediction_error_response(const std::string error_name, const std::string error_msg) {
+    rapidjson::Document error_response;
+    error_response.SetObject();
+    clipper::json::add_string(error_response, ERROR_RESPONSE_KEY_ERROR, error_name);
+    clipper::json::add_string(error_response, ERROR_RESPONSE_KEY_CAUSE, error_msg);
+    return clipper::json::to_json_string(error_response);
   }
 
   /*

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -34,6 +34,9 @@ namespace query_frontend {
 const std::string LOGGING_TAG_QUERY_FRONTEND = "QUERYFRONTEND";
 const std::string GET_METRICS = "^/metrics$";
 
+const std::string RESPONSE_KEY_OUTPUT = "output";
+const std::string RESPONSE_KEY_USED_DEFAULT = "default";
+
 const std::string PREDICTION_JSON_SCHEMA = R"(
   {
    "uid" := string,
@@ -158,6 +161,11 @@ class RequestHandler {
           Response r = f.get();
           std::stringstream ss;
           ss << "qid:" << r.query_id_ << ", predict:" << r.output_.y_hat_;
+
+          rapidjson::Document json_response;
+          clipper::json::add_double(json_response, RESPONSE_KEY_OUTPUT, r.output_.y_hat_);
+          clipper::json::
+
           std::string content = ss.str();
           respond_http(content, "200 OK", response);
         });

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -34,14 +34,14 @@ namespace query_frontend {
 const std::string LOGGING_TAG_QUERY_FRONTEND = "QUERYFRONTEND";
 const std::string GET_METRICS = "^/metrics$";
 
-const char* RESPONSE_KEY_QUERY_ID = "query_id";
-const char* RESPONSE_KEY_OUTPUT = "output";
-const char* RESPONSE_KEY_USED_DEFAULT = "default";
-const char* ERROR_RESPONSE_KEY_ERROR = "error";
-const char* ERROR_RESPONSE_KEY_CAUSE = "cause";
+const char* PREDICTION_RESPONSE_KEY_QUERY_ID = "query_id";
+const char* PREDICTION_RESPONSE_KEY_OUTPUT = "output";
+const char* PREDICTION_RESPONSE_KEY_USED_DEFAULT = "default";
+const char* PREDICTION_ERROR_RESPONSE_KEY_ERROR = "error";
+const char* PREDICTION_ERROR_RESPONSE_KEY_CAUSE = "cause";
 
-const std::string PREDICTION_ERROR_NAME_JSON = "Json Error";
-const std::string PREDICTION_ERROR_NAME_QUERY_PROCESSING = "Query Processing Error";
+const std::string PREDICTION_ERROR_NAME_JSON = "Json error";
+const std::string PREDICTION_ERROR_NAME_QUERY_PROCESSING = "Query processing error";
 
 const std::string PREDICTION_JSON_SCHEMA = R"(
   {
@@ -165,33 +165,28 @@ class RequestHandler {
                                       policy, latency_slo_micros, input_type);
         prediction.then([response](boost::future<Response> f) {
           Response r = f.get();
-          rapidjson::Document json_response;
-          json_response.SetObject();
-          clipper::json::add_long(json_response, RESPONSE_KEY_QUERY_ID, r.query_id_);
-          clipper::json::add_double(json_response, RESPONSE_KEY_OUTPUT, r.output_.y_hat_);
-          clipper::json::add_bool(json_response, RESPONSE_KEY_USED_DEFAULT, r.output_is_default_);
-          std::string content = clipper::json::to_json_string(json_response);
+          std::string content = get_prediction_response_content(r);
           respond_http(content, "200 OK", response);
         });
       } catch (const json_parse_error& e) {
         std::string error_msg =
             json_error_msg(e.what(), PREDICTION_JSON_SCHEMA);
-        std::string json_error_response = get_prediction_error_response(PREDICTION_ERROR_NAME_JSON, error_msg);
+        std::string json_error_response = get_prediction_error_response_content(PREDICTION_ERROR_NAME_JSON, error_msg);
         respond_http(json_error_response, "400 Bad Request", response);
       } catch (const json_semantic_error& e) {
         std::string error_msg =
             json_error_msg(e.what(), PREDICTION_JSON_SCHEMA);
-        std::string json_error_response = get_prediction_error_response(PREDICTION_ERROR_NAME_JSON, error_msg);
+        std::string json_error_response = get_prediction_error_response_content(PREDICTION_ERROR_NAME_JSON, error_msg);
         respond_http(json_error_response, "400 Bad Request", response);
       } catch (const std::invalid_argument& e) {
         // This invalid argument exception is most likely the propagation of an exception thrown
         // when Rapidjson attempts to parse an invalid json schema
-        std::string json_error_response = get_prediction_error_response(PREDICTION_ERROR_NAME_JSON, e.what());
+        std::string json_error_response = get_prediction_error_response_content(PREDICTION_ERROR_NAME_JSON, e.what());
         respond_http(json_error_response, "400 Bad Request", response);
       } catch (const clipper::PredictError& e) {
         std::string error_msg = e.what();
         std::string json_error_response =
-            get_prediction_error_response(PREDICTION_ERROR_NAME_QUERY_PROCESSING, error_msg);
+            get_prediction_error_response_content(PREDICTION_ERROR_NAME_QUERY_PROCESSING, error_msg);
         respond_http(json_error_response, "400 Bad Request", response);
       }
     };
@@ -225,11 +220,42 @@ class RequestHandler {
     server_.add_endpoint(update_endpoint, "POST", update_fn);
   }
 
-  const std::string get_prediction_error_response(const std::string error_name, const std::string error_msg) {
+  /**
+   * Obtains the json-formatted http response content for a successful query
+   *
+   * JSON format for prediction response:
+   * {
+   *    "query_id" := int,
+   *    "output" := float,
+   *    "default" := boolean
+   * }
+   */
+  static const std::string get_prediction_response_content(Response& query_response) {
+    rapidjson::Document json_response;
+    json_response.SetObject();
+    clipper::json::add_long(json_response, PREDICTION_RESPONSE_KEY_QUERY_ID, query_response.query_id_);
+    clipper::json::add_double(json_response, PREDICTION_RESPONSE_KEY_OUTPUT, query_response.output_.y_hat_);
+    clipper::json::add_bool(json_response, PREDICTION_RESPONSE_KEY_USED_DEFAULT, query_response.output_is_default_);
+    std::string content = clipper::json::to_json_string(json_response);
+    return content;
+  }
+
+  /**
+   * Obtains the json-formatted http response content for a query
+   * that could not be completed due to an error
+   *
+   * JSON format for error prediction response:
+   * {
+   *    "error" := string,
+   *    "cause" := string
+   * }
+   */
+  static const std::string get_prediction_error_response_content(
+      const std::string error_name, const std::string error_msg) {
     rapidjson::Document error_response;
     error_response.SetObject();
-    clipper::json::add_string(error_response, ERROR_RESPONSE_KEY_ERROR, error_name);
-    clipper::json::add_string(error_response, ERROR_RESPONSE_KEY_CAUSE, error_msg);
+    clipper::json::add_string(error_response, PREDICTION_ERROR_RESPONSE_KEY_ERROR, error_name);
+    clipper::json::add_string(error_response, PREDICTION_ERROR_RESPONSE_KEY_CAUSE, error_msg);
     return clipper::json::to_json_string(error_response);
   }
 
@@ -237,7 +263,7 @@ class RequestHandler {
    * JSON format for prediction query request:
    * {
    *  "uid" := string,
-   *  "input" := [double] | [int] | [string] | [byte] | [float],
+   *  "input" := [double] | [int] | [string] | [byte] | [float]
    * }
    */
   boost::future<Response> decode_and_handle_predict(

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -138,7 +138,7 @@ class RequestHandler {
     // selection policies have a default output?
     //
     // Initialize selection state for this application
-    if (policy == "DefaultOutputSelectionPolicy") {
+    if (policy == clipper::DefaultOutputSelectionPolicy::get_name()) {
       clipper::DefaultOutputSelectionPolicy p;
       clipper::Output parsed_default_output(std::stod(default_output), {});
       auto init_state = p.init_state(parsed_default_output);

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -21,6 +21,10 @@ class MockQueryProcessor {
   boost::future<FeedbackAck> update(FeedbackQuery /*feedback*/) {
     return boost::make_ready_future(true);
   }
+
+  std::shared_ptr<StateDB> get_state_table() const {
+    return std::shared_ptr<StateDB>();
+  }
 };
 
 class QueryFrontendTest : public ::testing::Test {
@@ -46,7 +50,7 @@ TEST_F(QueryFrontendTest, TestDecodeCorrectInputInts) {
   std::vector<int> expected_input{1, 2, 3, 4};
   EXPECT_EQ(parsed_input, expected_input);
   EXPECT_EQ(parsed_query.label_, "test");
-  EXPECT_EQ(parsed_query.latency_micros_, 30000);
+  EXPECT_EQ(parsed_query.latency_budget_micros_, 30000);
   EXPECT_EQ(parsed_query.selection_policy_, "test_policy");
 }
 
@@ -66,7 +70,7 @@ TEST_F(QueryFrontendTest, TestDecodeCorrectInputDoubles) {
   std::vector<double> expected_input{1.4, 2.23, 3.243242, 0.3223424};
   EXPECT_EQ(parsed_input, expected_input);
   EXPECT_EQ(parsed_query.label_, "test");
-  EXPECT_EQ(parsed_query.latency_micros_, 30000);
+  EXPECT_EQ(parsed_query.latency_budget_micros_, 30000);
   EXPECT_EQ(parsed_query.selection_policy_, "test_policy");
 }
 
@@ -89,7 +93,7 @@ TEST_F(QueryFrontendTest, TestDecodeCorrectInputString) {
       "hello world. This is a test string with punctionation!@#$Y#;}#");
   EXPECT_EQ(parsed_input, expected_input);
   EXPECT_EQ(parsed_query.label_, "test");
-  EXPECT_EQ(parsed_query.latency_micros_, 30000);
+  EXPECT_EQ(parsed_query.latency_budget_micros_, 30000);
   EXPECT_EQ(parsed_query.selection_policy_, "test_policy");
 }
 

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -150,7 +150,7 @@ TEST_F(QueryFrontendTest, TestAddOneApplication) {
   size_t no_apps = rh_.num_applications();
   EXPECT_EQ(no_apps, (size_t)0);
   rh_.add_application("test_app_1", {}, InputType::Doubles, "test_policy",
-                      30000);
+                      "0.4", 30000);
   size_t one_app = rh_.num_applications();
   EXPECT_EQ(one_app, (size_t)1);
 }
@@ -161,7 +161,8 @@ TEST_F(QueryFrontendTest, TestAddManyApplications) {
 
   for (int i = 0; i < 500; ++i) {
     std::string cur_name = "test_app_" + std::to_string(i);
-    rh_.add_application(cur_name, {}, InputType::Doubles, "test_policy", 30000);
+    rh_.add_application(cur_name, {}, InputType::Doubles, "test_policy", "0.4",
+                        30000);
   }
 
   size_t apps = rh_.num_applications();

--- a/src/libclipper/CMakeLists.txt
+++ b/src/libclipper/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(clipper
     src/containers.cpp
     src/redis.cpp
     src/logging.cpp
+    src/json_util.cpp
     )
 
 

--- a/src/libclipper/include/clipper/constants.hpp
+++ b/src/libclipper/include/clipper/constants.hpp
@@ -27,5 +27,7 @@ const std::string ITEM_PART_CONCATENATOR = ":";
 
 const std::string LOGGING_TAG_CLIPPER = "Clipper";
 
+constexpr int DEFAULT_USER_ID = 0;
+
 }  // namespace clipper
 #endif

--- a/src/libclipper/include/clipper/datatypes.hpp
+++ b/src/libclipper/include/clipper/datatypes.hpp
@@ -191,7 +191,7 @@ class Query {
   ~Query() = default;
 
   Query(std::string label, long user_id, std::shared_ptr<Input> input,
-        long latency_micros, std::string selection_policy,
+        long deadline, std::string selection_policy,
         std::vector<VersionedModelId> candidate_models);
 
   // Note that it should be relatively cheap to copy queries because
@@ -210,7 +210,7 @@ class Query {
   std::string label_;
   long user_id_;
   std::shared_ptr<Input> input_;
-  long latency_micros_;
+  long deadline_;
   std::string selection_policy_;
   std::vector<VersionedModelId> candidate_models_;
   std::chrono::time_point<std::chrono::high_resolution_clock> create_time_;

--- a/src/libclipper/include/clipper/datatypes.hpp
+++ b/src/libclipper/include/clipper/datatypes.hpp
@@ -40,6 +40,8 @@ class Output {
   Output(Output &&) = default;
   Output &operator=(Output &&) = default;
   Output(double y_hat, std::vector<VersionedModelId> models_used);
+  bool operator==(const Output &rhs) const;
+  bool operator!=(const Output &rhs) const;
   double y_hat_;
   std::vector<VersionedModelId> models_used_;
 };

--- a/src/libclipper/include/clipper/datatypes.hpp
+++ b/src/libclipper/include/clipper/datatypes.hpp
@@ -210,6 +210,7 @@ class Query {
   std::string label_;
   long user_id_;
   std::shared_ptr<Input> input_;
+  // TODO change this to a deadline instead of a duration
   long latency_budget_micros_;
   std::string selection_policy_;
   std::vector<VersionedModelId> candidate_models_;

--- a/src/libclipper/include/clipper/datatypes.hpp
+++ b/src/libclipper/include/clipper/datatypes.hpp
@@ -223,8 +223,8 @@ class Response {
  public:
   ~Response() = default;
 
-  Response(Query query, QueryId query_id, long duration_micros, Output output,
-           std::vector<VersionedModelId> models_used);
+  Response(Query query, QueryId query_id, const long duration_micros, Output output,
+           const bool is_default, std::vector<VersionedModelId> models_used);
 
   // default copy constructors
   Response(const Response &) = default;
@@ -240,6 +240,7 @@ class Response {
   QueryId query_id_;
   long duration_micros_;
   Output output_;
+  bool output_is_default_;
   std::vector<VersionedModelId> models_used_;
 };
 

--- a/src/libclipper/include/clipper/datatypes.hpp
+++ b/src/libclipper/include/clipper/datatypes.hpp
@@ -191,7 +191,7 @@ class Query {
   ~Query() = default;
 
   Query(std::string label, long user_id, std::shared_ptr<Input> input,
-        long deadline, std::string selection_policy,
+        long latency_budget_micros, std::string selection_policy,
         std::vector<VersionedModelId> candidate_models);
 
   // Note that it should be relatively cheap to copy queries because
@@ -210,7 +210,7 @@ class Query {
   std::string label_;
   long user_id_;
   std::shared_ptr<Input> input_;
-  long deadline_;
+  long latency_budget_micros_;
   std::string selection_policy_;
   std::vector<VersionedModelId> candidate_models_;
   std::chrono::time_point<std::chrono::high_resolution_clock> create_time_;

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -1,6 +1,7 @@
 #ifndef CLIPPER_LIB_JSON_UTIL_H
 #define CLIPPER_LIB_JSON_UTIL_H
 
+#include <sstream>
 #include <stdexcept>
 
 #include <rapidjson/document.h>

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -45,7 +45,9 @@ rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
                                            const char* key_name,
                                            Type expected_type);
 
-/* Getters with error handling for double, float, long, int, string */
+/* Getters with error handling for bool, double, float, long, int, string */
+bool get_bool(rapidjson::Value& d, const char* key_name);
+
 double get_double(rapidjson::Value& d, const char* key_name);
 
 float get_float(rapidjson::Value& d, const char* key_name);
@@ -78,6 +80,8 @@ std::shared_ptr<Input> parse_input(InputType input_type, rapidjson::Value& d);
 /* Utilities for serialization into JSON */
 void add_kv_pair(rapidjson::Document& d, const char* key_name,
                  rapidjson::Value& value_to_add);
+
+void add_bool(rapidjson::Document& d, const char* key_name, bool value_to_add);
 
 void add_double_array(rapidjson::Document& d, const char* key_name,
                       std::vector<double>& values_to_add);

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -1,13 +1,7 @@
 #ifndef CLIPPER_LIB_JSON_UTIL_H
 #define CLIPPER_LIB_JSON_UTIL_H
 
-#include <sstream>
-#include <stdexcept>
-
 #include <rapidjson/document.h>
-#include <rapidjson/error/en.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
 #include <clipper/datatypes.hpp>
 
@@ -36,312 +30,82 @@ namespace json {
 
 class json_parse_error : public std::runtime_error {
  public:
-  json_parse_error(const std::string& what) : std::runtime_error(what) {}
-  ~json_parse_error() throw(){};
+  json_parse_error(const std::string& what);
+  ~json_parse_error() throw();
 };
 
 class json_semantic_error : public std::runtime_error {
  public:
-  json_semantic_error(const std::string& what) : std::runtime_error(what) {}
-  ~json_semantic_error() throw(){};
+  json_semantic_error(const std::string& what);
+  ~json_semantic_error() throw();
 };
 
 /* Check for matching types else throw exception */
 rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
                                            const char* key_name,
-                                           Type expected_type) {
-  if (!d.IsObject()) {
-    throw json_semantic_error("Can only get key-value pair from an object");
-  } else if (!d.HasMember(key_name)) {
-    throw json_semantic_error("JSON object does not have required key: " +
-                              std::string(key_name));
-  }
-  rapidjson::Value& val = d[key_name];
-  if (val.GetType() != expected_type) {
-    throw json_semantic_error("Type mismatch! JSON key " +
-                              std::string(key_name) + " expected type " +
-                              kTypeNames[expected_type] + "but found type " +
-                              kTypeNames[val.GetType()]);
-  }
-  return val;
-}
+                                           Type expected_type);
 
 /* Getters with error handling for double, float, long, int, string */
-double get_double(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
-  if (!v.IsDouble()) {
-    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
-                              " is not of type double");
-  }
-  return v.GetDouble();
-}
+double get_double(rapidjson::Value& d, const char* key_name);
 
-float get_float(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
-  if (!v.IsFloat()) {
-    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
-                              " is not of type float");
-  }
-  return v.GetFloat();
-}
+float get_float(rapidjson::Value& d, const char* key_name);
 
-long get_long(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
-  if (!v.IsInt64()) {
-    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
-                              " is not of type long");
-  }
-  return static_cast<long>(v.GetInt64());
-}
+long get_long(rapidjson::Value& d, const char* key_name);
 
-int get_int(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
-  if (!v.IsInt()) {
-    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
-                              " is not of type int");
-  }
-  return v.GetInt();
-}
+int get_int(rapidjson::Value& d, const char* key_name);
 
-std::string get_string(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kStringType);
-  if (!v.IsString()) {
-    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
-                              " is not of type string");
-  }
-  return std::string(v.GetString());
-}
+std::string get_string(rapidjson::Value& d, const char* key_name);
 
 /* Getters with error handling for arrays of double, float, int, string */
-std::vector<double> get_double_array(rapidjson::Value& d,
-                                     const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
-  std::vector<double> vals;
-  vals.reserve(v.Capacity());
-  for (rapidjson::Value& elem : v.GetArray()) {
-    if (!elem.IsDouble()) {
-      throw json_semantic_error("Array input of type " +
-                                kTypeNames[elem.GetType()] +
-                                " is not of type double");
-    }
-    vals.push_back(elem.GetDouble());
-  }
-  return vals;
-}
+std::vector<double> get_double_array(rapidjson::Value& d, const char* key_name);
 
-std::vector<float> get_float_array(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
-  std::vector<float> vals;
-  vals.reserve(v.Capacity());
-  for (rapidjson::Value& elem : v.GetArray()) {
-    if (!elem.IsFloat()) {
-      throw json_semantic_error("Array input of type " +
-                                kTypeNames[elem.GetType()] +
-                                " is not of type float");
-    }
-    vals.push_back(elem.GetFloat());
-  }
-  return vals;
-}
+std::vector<float> get_float_array(rapidjson::Value& d, const char* key_name);
 
-std::vector<int> get_int_array(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
-  std::vector<int> vals;
-  vals.reserve(v.Capacity());
-  for (rapidjson::Value& elem : v.GetArray()) {
-    if (!elem.IsInt()) {
-      throw json_semantic_error("Array input of type " +
-                                kTypeNames[elem.GetType()] +
-                                " is not of type int");
-    }
-    vals.push_back(elem.GetInt());
-  }
-  return vals;
-}
+std::vector<int> get_int_array(rapidjson::Value& d, const char* key_name);
 
 std::vector<std::string> get_string_array(rapidjson::Value& d,
-                                          const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
-  std::vector<std::string> vals;
-  vals.reserve(v.Capacity());
-  for (rapidjson::Value& elem : v.GetArray()) {
-    if (!elem.IsString()) {
-      throw json_semantic_error("Array input of type " +
-                                kTypeNames[elem.GetType()] +
-                                " is not of type string");
-    }
-    vals.push_back(elem.GetString());
-  }
-  return vals;
-}
+                                          const char* key_name);
 
 std::vector<VersionedModelId> get_candidate_models(rapidjson::Value& d,
-                                                   const char* key_name) {
-  rapidjson::Value& v =
-      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
-  std::vector<VersionedModelId> candidate_models;
-  candidate_models.reserve(v.Capacity());
-  for (rapidjson::Value& elem : v.GetArray()) {
-    if (!elem.IsObject()) {
-      throw json_semantic_error("Array input of type " +
-                                kTypeNames[elem.GetType()] +
-                                " is not of type Object");
-    } else if (!elem.HasMember("model_name")) {
-      throw json_semantic_error(
-          "Candidate model JSON object missing model_name.");
-    } else if (!elem.HasMember("model_version")) {
-      throw json_semantic_error(
-          "Candidate model JSON object missing model_version.");
-    }
-    std::string model_name = get_string(elem, "model_name");
-    int model_version = get_int(elem, "model_version");
-    candidate_models.push_back(std::make_pair(model_name, model_version));
-  }
-  return candidate_models;
-}
+                                                   const char* key_name);
 
-rapidjson::Value& get_object(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& object =
-      check_kv_type_and_return(d, key_name, rapidjson::kObjectType);
-  return object;
-}
+rapidjson::Value& get_object(rapidjson::Value& d, const char* key_name);
 
-void parse_json(const std::string& json_content, rapidjson::Document& d) {
-  rapidjson::ParseResult ok = d.Parse(json_content.c_str());
-  if (!ok) {
-    std::stringstream ss;
-    ss << "JSON parse error: " << rapidjson::GetParseError_En(ok.Code())
-       << " (offset " << ok.Offset() << ")\n";
-    throw json_parse_error(ss.str());
-  }
-}
+void parse_json(const std::string& json_content, rapidjson::Document& d);
 
-std::shared_ptr<Input> parse_input(InputType input_type, rapidjson::Value& d) {
-  switch (input_type) {
-    case InputType::Doubles: {
-      std::vector<double> inputs = get_double_array(d, "input");
-      return std::make_shared<clipper::DoubleVector>(inputs);
-    }
-    case InputType::Floats: {
-      std::vector<float> inputs = get_float_array(d, "input");
-      return std::make_shared<clipper::FloatVector>(inputs);
-    }
-    case InputType::Ints: {
-      std::vector<int> inputs = get_int_array(d, "input");
-      return std::make_shared<clipper::IntVector>(inputs);
-    }
-    case InputType::Strings: {
-      std::string input_string = get_string(d, "input");
-      return std::make_shared<clipper::SerializableString>(input_string);
-    }
-    case InputType::Bytes: {
-      throw std::invalid_argument("Base64 encoded bytes are not supported yet");
-    }
-    default: throw std::invalid_argument("input_type is not a valid type");
-  }
-}
+std::shared_ptr<Input> parse_input(InputType input_type, rapidjson::Value& d);
 
 /* Utilities for serialization into JSON */
 void add_kv_pair(rapidjson::Document& d, const char* key_name,
-                 rapidjson::Value& value_to_add) {
-  if (!d.IsObject()) {
-    throw json_semantic_error("Can only add a key-value pair to an object");
-  } else if (d.HasMember(key_name)) {
-    // Remove old value associated with key_name
-    d.RemoveMember(key_name);
-  }
-  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
-  rapidjson::Value key(key_name, allocator);
-  d.AddMember(key, value_to_add, allocator);
-}
+                 rapidjson::Value& value_to_add);
 
 void add_double_array(rapidjson::Document& d, const char* key_name,
-                      std::vector<double>& values_to_add) {
-  rapidjson::Value double_array(rapidjson::kArrayType);
-  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
-  for (std::size_t i = 0; i < values_to_add.size(); i++) {
-    double_array.PushBack(values_to_add[i], allocator);
-  }
-  add_kv_pair(d, key_name, double_array);
-}
+                      std::vector<double>& values_to_add);
 
 void add_float_array(rapidjson::Document& d, const char* key_name,
-                     std::vector<float>& values_to_add) {
-  rapidjson::Value float_array(rapidjson::kArrayType);
-  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
-  for (std::size_t i = 0; i < values_to_add.size(); i++) {
-    float_array.PushBack(values_to_add[i], allocator);
-  }
-  add_kv_pair(d, key_name, float_array);
-}
+                     std::vector<float>& values_to_add);
 
 void add_int_array(rapidjson::Document& d, const char* key_name,
-                   std::vector<int>& values_to_add) {
-  rapidjson::Value int_array(rapidjson::kArrayType);
-  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
-  for (std::size_t i = 0; i < values_to_add.size(); i++) {
-    int_array.PushBack(values_to_add[i], allocator);
-  }
-  add_kv_pair(d, key_name, int_array);
-}
+                   std::vector<int>& values_to_add);
 
 void add_string_array(rapidjson::Document& d, const char* key_name,
-                      std::vector<std::string>& values_to_add) {
-  rapidjson::Value string_array(rapidjson::kArrayType);
-  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
-  for (std::size_t i = 0; i < values_to_add.size(); i++) {
-    rapidjson::Value string_val(values_to_add[i].c_str(), allocator);
-    string_array.PushBack(string_val, allocator);
-  }
-  add_kv_pair(d, key_name, string_array);
-}
+                      std::vector<std::string>& values_to_add);
 
-void add_double(rapidjson::Document& d, const char* key_name, double val) {
-  rapidjson::Value val_to_add(val);
-  add_kv_pair(d, key_name, val_to_add);
-}
+void add_double(rapidjson::Document& d, const char* key_name, double val);
 
-void add_float(rapidjson::Document& d, const char* key_name, float val) {
-  rapidjson::Value val_to_add(val);
-  add_kv_pair(d, key_name, val_to_add);
-}
+void add_float(rapidjson::Document& d, const char* key_name, float val);
 
-void add_int(rapidjson::Document& d, const char* key_name, int val) {
-  rapidjson::Value val_to_add(val);
-  add_kv_pair(d, key_name, val_to_add);
-}
+void add_int(rapidjson::Document& d, const char* key_name, int val);
 
-void add_long(rapidjson::Document& d, const char* key_name, long val) {
-  rapidjson::Value val_to_add((int64_t)val);
-  add_kv_pair(d, key_name, val_to_add);
-}
+void add_long(rapidjson::Document& d, const char* key_name, long val);
 
 void add_string(rapidjson::Document& d, const char* key_name,
-                const std::string& val) {
-  rapidjson::Value val_to_add(val.c_str(), d.GetAllocator());
-  add_kv_pair(d, key_name, val_to_add);
-}
+                const std::string& val);
 
 void add_object(rapidjson::Document& d, const char* key_name,
-                rapidjson::Document& to_add) {
-  add_kv_pair(d, key_name, to_add);
-}
+                rapidjson::Document& to_add);
 
-std::string to_json_string(rapidjson::Document& d) {
-  rapidjson::StringBuffer buffer;
-  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-  d.Accept(writer);
-  return buffer.GetString();
-}
+std::string to_json_string(rapidjson::Document& d);
 
 }  // namespace json
 }  // namespace clipper

--- a/src/libclipper/include/clipper/persistent_state.hpp
+++ b/src/libclipper/include/clipper/persistent_state.hpp
@@ -25,7 +25,7 @@ size_t state_key_hash(const StateKey& key);
 // Threadsafe, non-copyable state storage
 class StateDB {
  public:
-  StateDB();
+  explicit StateDB();
   ~StateDB();
 
   // Disallow copies because of the mutex

--- a/src/libclipper/include/clipper/persistent_state.hpp
+++ b/src/libclipper/include/clipper/persistent_state.hpp
@@ -25,7 +25,7 @@ size_t state_key_hash(const StateKey& key);
 // Threadsafe, non-copyable state storage
 class StateDB {
  public:
-  explicit StateDB();
+  StateDB();
   ~StateDB();
 
   // Disallow copies because of the mutex

--- a/src/libclipper/include/clipper/query_processor.hpp
+++ b/src/libclipper/include/clipper/query_processor.hpp
@@ -17,14 +17,6 @@
 
 namespace clipper {
 
-// // For the purpose of testing
-// class QueryProcessorBase {
-//  public:
-//   QueryProcessorBase() {}
-//   virtual boost::future<Response> predict(Query query) = 0;
-//   virtual boost::future<FeedbackAck> update(FeedbackQuery feedback) = 0;
-// };
-
 const std::string LOGGING_TAG_QUERY_PROCESSOR = "QUERYPROCESSOR";
 
 class QueryProcessor {
@@ -51,6 +43,16 @@ class QueryProcessor {
   std::shared_ptr<StateDB> state_db_;
   TaskExecutor task_executor_;
   TimerSystem<HighPrecisionClock> timer_system_{HighPrecisionClock()};
+  // This is a heteregenous container of different instances of selection
+  // policy.
+  // The key is the name of the specific selection policy, the value is an
+  // instance
+  // of that policy. All SelectionPolicy implementations (derived classes)
+  // should
+  // be stateless so there should be no issues with re-using the same instance
+  // for different applications or users.
+  std::unordered_map<std::string, std::shared_ptr<SelectionPolicy>>
+      selection_policies_;
 };
 
 }  // namespace clipper

--- a/src/libclipper/include/clipper/query_processor.hpp
+++ b/src/libclipper/include/clipper/query_processor.hpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include <boost/thread.hpp>
+#include <boost/optional.hpp>
 
 #include "datatypes.hpp"
 #include "persistent_state.hpp"
@@ -53,6 +54,16 @@ class QueryProcessor {
   // for different applications or users.
   std::unordered_map<std::string, std::shared_ptr<SelectionPolicy>>
       selection_policies_;
+};
+
+class PredictError : public std::runtime_error {
+ public:
+  PredictError(const long query_id, const std::string msg);
+  const char* what() const noexcept;
+
+ private:
+  const long query_id_;
+  const std::string msg_;
 };
 
 }  // namespace clipper

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -200,6 +200,7 @@ std::unordered_map<std::string, std::string> get_container_by_key(
 bool add_application(redox::Redox& redis, const std::string& appname,
                      const std::vector<VersionedModelId>& models,
                      const InputType& input_type, const std::string& policy,
+                     const std::string& default_output,
                      const long latency_slo_micros);
 
 /**

--- a/src/libclipper/include/clipper/selection_policies.hpp
+++ b/src/libclipper/include/clipper/selection_policies.hpp
@@ -12,6 +12,20 @@ namespace clipper {
 
 const std::string LOGGING_TAG_SELECTION_POLICY = "SELECTIONPOLICY";
 
+/**
+ * An instance of a SelectionPolicy class must be stateless and Clipper
+ * provides no guarantees about which instance of a SelectionPolicy
+ * will be used at any given time. The only reason SelectionPolicy
+ * objects are created at all is that in C++ using object hierarchies
+ * is the simplest way to achieve the type of polymorphic specialization
+ * we need for selection policies.
+ *
+ * Because these SelectionPolicy instances are stateless, all state
+ * needed for processing is encapsulated in a SelectionState object
+ * which is managed by Clipper and stored in a persistent
+ * database. The separate of policy and state allows Clipper to re-use
+ * the same SelectionPolicy instance with different SelectionStates.
+ */
 class SelectionState {
  public:
   SelectionState() = default;
@@ -102,6 +116,9 @@ class DefaultOutputSelectionPolicy : public SelectionPolicy {
   DefaultOutputSelectionPolicy& operator=(DefaultOutputSelectionPolicy&&) =
       default;
   ~DefaultOutputSelectionPolicy() = default;
+
+  static std::string get_name() const;
+
   std::shared_ptr<SelectionState> init_state(Output default_output) const;
 
   std::vector<PredictTask> select_predict_tasks(

--- a/src/libclipper/include/clipper/selection_policies.hpp
+++ b/src/libclipper/include/clipper/selection_policies.hpp
@@ -19,10 +19,6 @@ class SelectionState {
   SelectionState& operator=(const SelectionState&) = default;
   SelectionState(SelectionState&&) = default;
   SelectionState& operator=(SelectionState&&) = default;
-  /**
-   * Constructor to create a SelectionState object from serialized
-   * representation.
-   */
   virtual ~SelectionState();
   virtual std::string get_debug_string() const = 0;
 };
@@ -41,22 +37,6 @@ class SelectionPolicy {
   SelectionPolicy(SelectionPolicy&&) = default;
   SelectionPolicy& operator=(SelectionPolicy&&) = default;
   virtual ~SelectionPolicy();
-  // virtual SelectionState initialize(
-  //     const std::vector<VersionedModelId>& candidate_models) const = 0;
-  // virtual std::shared_ptr<SelectionState> update_candidate_models(
-  //     std::shared_ptr<SelectionState> state,
-  //     const std::vector<VersionedModelId>& candidate_models) const = 0;
-
-  // Used to identify a unique selection policy instance. For example,
-  // if using a bandit-algorithm that does not tolerate variable-armed
-  // bandits, one could hash the candidate models to identify
-  // which policy instance corresponds to this exact set of arms.
-  // Similarly, it provides flexibility in how to deal with different
-  // versions of the same arm (different versions of same model).
-  virtual long hash_models(
-      const std::vector<VersionedModelId>& /*models*/) const {
-    return 0;
-  }
 
   // Query Pre-processing: select models and generate tasks
   virtual std::vector<PredictTask> select_predict_tasks(

--- a/src/libclipper/include/clipper/selection_policies.hpp
+++ b/src/libclipper/include/clipper/selection_policies.hpp
@@ -117,7 +117,7 @@ class DefaultOutputSelectionPolicy : public SelectionPolicy {
       default;
   ~DefaultOutputSelectionPolicy() = default;
 
-  static std::string get_name() const;
+  static std::string get_name();
 
   std::shared_ptr<SelectionState> init_state(Output default_output) const;
 

--- a/src/libclipper/include/clipper/selection_policies.hpp
+++ b/src/libclipper/include/clipper/selection_policies.hpp
@@ -57,7 +57,12 @@ class SelectionPolicy {
       std::shared_ptr<SelectionState> state, Query query,
       long query_id) const = 0;
 
-  virtual Output combine_predictions(
+  /// Combines multiple prediction results to produce a single
+  /// output for a query.
+  ///
+  /// @returns A pair containing the output and a boolean flag
+  /// indicating whether or not it is the default output
+  virtual const std::pair<Output, bool> combine_predictions(
       const std::shared_ptr<SelectionState>& state, Query query,
       std::vector<Output> predictions) const = 0;
 
@@ -125,9 +130,10 @@ class DefaultOutputSelectionPolicy : public SelectionPolicy {
       std::shared_ptr<SelectionState> state, Query query,
       long query_id) const override;
 
-  Output combine_predictions(const std::shared_ptr<SelectionState>& state,
-                             Query query,
-                             std::vector<Output> predictions) const override;
+  const std::pair<Output, bool>
+  combine_predictions(const std::shared_ptr<SelectionState>& state,
+                      Query query,
+                      std::vector<Output> predictions) const override;
 
   std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
   select_feedback_tasks(const std::shared_ptr<SelectionState>& state,

--- a/src/libclipper/include/clipper/selection_policies.hpp
+++ b/src/libclipper/include/clipper/selection_policies.hpp
@@ -19,7 +19,7 @@ class SelectionState {
   SelectionState& operator=(const SelectionState&) = default;
   SelectionState(SelectionState&&) = default;
   SelectionState& operator=(SelectionState&&) = default;
-  virtual ~SelectionState();
+  virtual ~SelectionState() = default;
   virtual std::string get_debug_string() const = 0;
 };
 
@@ -36,7 +36,7 @@ class SelectionPolicy {
   SelectionPolicy& operator=(const SelectionPolicy&) = default;
   SelectionPolicy(SelectionPolicy&&) = default;
   SelectionPolicy& operator=(SelectionPolicy&&) = default;
-  virtual ~SelectionPolicy();
+  virtual ~SelectionPolicy() = default;
 
   // Query Pre-processing: select models and generate tasks
   virtual std::vector<PredictTask> select_predict_tasks(

--- a/src/libclipper/include/clipper/selection_policies.hpp
+++ b/src/libclipper/include/clipper/selection_policies.hpp
@@ -8,75 +8,38 @@
 #include "datatypes.hpp"
 #include "task_executor.hpp"
 
-/**
- * IMPORTANT NOTES FOR USING SELECTION POLICIES
- * The selection policy only supports binary classfication models
- * The binary classes must use 0 as negative class indicator and 1 as positive
- * class indicator
- */
-
 namespace clipper {
 
 const std::string LOGGING_TAG_SELECTION_POLICY = "SELECTIONPOLICY";
 
-// *********
-// * State *
-// *********
-
-/**
- * Model Information
- * Each model has properties and we use an unordered_map to contain these
- * properties
- *  - EXP3/EXP4 Model Properties:
- *    "weight": weight of this model
- *  - EpsilonGreedy/UCB Properties:
- *    "expected_loss": the mean of the loss distribution of this model
- *    "times_selected": how many times we have used this model
- */
-using ModelInfo = std::unordered_map<std::string, double>;
-
-/** Model Map
- * A map of the models to their corresponding model information
- */
-using Map = std::unordered_map<VersionedModelId, ModelInfo,
-                               std::function<size_t(const VersionedModelId&)>>;
-
-class BanditPolicyState {
+class SelectionState {
  public:
-  BanditPolicyState() = default;
-  ~BanditPolicyState() = default;
-
-  void set_model_map(Map map);
-  void add_model(VersionedModelId id, ModelInfo model);
-  void set_weight_sum(double sum);
-  std::string serialize() const;
-  static BanditPolicyState deserialize(const std::string& bytes);
-  std::string debug_string() const;
-  Map model_map_;
-  double weight_sum_ = 0.0;  // Only for Exp3, Exp4
+  SelectionState() = default;
+  SelectionState(const SelectionState&) = default;
+  SelectionState& operator=(const SelectionState&) = default;
+  SelectionState(SelectionState&&) = default;
+  SelectionState& operator=(SelectionState&&) = default;
+  /**
+   * Constructor to create a SelectionState object from serialized
+   * representation.
+   */
+  virtual ~SelectionState();
+  virtual std::string get_debug_string() const = 0;
 };
 
-// **********
-// * Policy *
-// **********
-
-template <typename Derived>
 class SelectionPolicy {
  public:
-  // Don't let this class be instantiated
-  SelectionPolicy() = delete;
-  ~SelectionPolicy() = delete;
-
-  static BanditPolicyState initialize(
-      const std::vector<VersionedModelId>& candidate_models) {
-    return Derived::initialize(candidate_models);
-  };
-
-  static BanditPolicyState add_models(
-      BanditPolicyState state,
-      const std::vector<VersionedModelId>& new_models) {
-    return Derived::add_models(state, new_models);
-  };
+  SelectionPolicy() = default;
+  SelectionPolicy(const SelectionPolicy&) = default;
+  SelectionPolicy& operator=(const SelectionPolicy&) = default;
+  SelectionPolicy(SelectionPolicy&&) = default;
+  SelectionPolicy& operator=(SelectionPolicy&&) = default;
+  virtual ~SelectionPolicy();
+  // virtual SelectionState initialize(
+  //     const std::vector<VersionedModelId>& candidate_models) const = 0;
+  virtual SelectionState update_candidate_models(
+      SelectionState state,
+      const std::vector<VersionedModelId>& candidate_models) const = 0;
 
   // Used to identify a unique selection policy instance. For example,
   // if using a bandit-algorithm that does not tolerate variable-armed
@@ -84,248 +47,96 @@ class SelectionPolicy {
   // which policy instance corresponds to this exact set of arms.
   // Similarly, it provides flexibility in how to deal with different
   // versions of the same arm (different versions of same model).
-  static long hash_models(
-      const std::vector<VersionedModelId>& candidate_models) {
-    return Derived::hash_models(candidate_models);
+  virtual long hash_models(
+      const std::vector<VersionedModelId>& /*models*/) const {
+    return 0;
   }
 
   // Query Pre-processing: select models and generate tasks
-  static std::vector<PredictTask> select_predict_tasks(BanditPolicyState state,
-                                                       Query query,
-                                                       long query_id) {
-    return Derived::select_predict_tasks(state, query, query_id);
-  }
+  virtual std::vector<PredictTask> select_predict_tasks(
+      SelectionState state, Query query, long query_id) const = 0;
 
-  // TODO: change this method name
-  // TODO: I think it may make sense to decouple combine_predictions()
-  // from select_predict_tasks in some cases
-  static Output combine_predictions(BanditPolicyState state, Query query,
-                                    std::vector<Output> predictions) {
-    return Derived::combine_predictions(state, query, predictions);
-  }
+  virtual Output combine_predictions(const SelectionState& state, Query query,
+                                     std::vector<Output> predictions) const = 0;
 
   /// When feedback is received, the selection policy can choose
   /// to schedule both feedback and prediction tasks. Prediction tasks
   /// can be used to get y_hat for e.g. updating a bandit algorithm,
   /// while feedback tasks can be used to optionally propogate feedback
   /// into the model containers.
-  static std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-  select_feedback_tasks(BanditPolicyState& state, FeedbackQuery query,
-                        long query_id) {
-    return Derived::select_feedback_tasks(state, query, query_id);
-  }
+  virtual std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
+  select_feedback_tasks(const SelectionState& state, FeedbackQuery query,
+                        long query_id) const = 0;
 
   /// This method will be called if at least one PredictTask
   /// was scheduled for this piece of feedback. This method
   /// is guaranteed to be called sometime after all the predict
   /// tasks scheduled by `select_feedback_tasks` complete.
-  static BanditPolicyState process_feedback(BanditPolicyState state,
-                                            Feedback feedback,
-                                            std::vector<Output> predictions) {
-    return Derived::process_feedback(state, feedback, predictions);
-  }
+  virtual SelectionState process_feedback(
+      SelectionState state, Feedback feedback,
+      std::vector<Output> predictions) const = 0;
 
-  static std::string serialize_state(BanditPolicyState state) {
-    return Derived::serialize_state(state);
-  }
-
-  static BanditPolicyState deserialize_state(const std::string& bytes) {
-    return Derived::deserialize_state(bytes);
-  }
-
-  /* Human readable debug string for the state */
-  static std::string state_debug_string(const BanditPolicyState& state) {
-    return Derived::state_debug_string(state);
-  }
+  virtual SelectionState deserialize(std::string serialized_state) const = 0;
+  virtual std::string serialize(SelectionState state) const = 0;
 };
 
-class Exp3Policy : public SelectionPolicy<Exp3Policy> {
-  // Exp3
-  // Select: weighted sampling
-  // Update: update weights based on Loss and respond rate
+////////////////////////////////////////////////////////////////////
 
+class DefaultOutputSelectionState : public SelectionState {
  public:
-  Exp3Policy() = delete;
-  ~Exp3Policy() = delete;
-  typedef BanditPolicyState state_type;
-
-  constexpr static double eta = 0.01;  // How fast clipper respond to feedback
-
-  static BanditPolicyState initialize(
-      const std::vector<VersionedModelId>& candidate_models);
-
-  static BanditPolicyState add_models(
-      BanditPolicyState state, const std::vector<VersionedModelId>& new_models);
-
-  static long hash_models(
-      const std::vector<VersionedModelId>& /*candidate_models*/) {
-    return 0;
-  };
-
-  static std::vector<PredictTask> select_predict_tasks(BanditPolicyState state,
-                                                       Query query,
-                                                       long query_id);
-
-  static Output combine_predictions(BanditPolicyState state, Query query,
-                                    std::vector<Output> predictions);
-
-  static std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-  select_feedback_tasks(BanditPolicyState& state, FeedbackQuery query,
-                        long query_id);
-
-  static BanditPolicyState process_feedback(BanditPolicyState state,
-                                            Feedback feedback,
-                                            std::vector<Output> predictions);
-
-  static std::string serialize_state(BanditPolicyState state);
-
-  static BanditPolicyState deserialize_state(const std::string& bytes);
-
-  static std::string state_debug_string(const BanditPolicyState& state);
+  DefaultOutputSelectionState() = default;
+  DefaultOutputSelectionState(const DefaultOutputSelectionState&) = default;
+  DefaultOutputSelectionState& operator=(const DefaultOutputSelectionState&) =
+      default;
+  DefaultOutputSelectionState(DefaultOutputSelectionState&&) = default;
+  DefaultOutputSelectionState& operator=(DefaultOutputSelectionState&&) =
+      default;
+  explicit DefaultOutputSelectionState(Output default_output);
+  explicit DefaultOutputSelectionState(std::string serialized_state);
+  ~DefaultOutputSelectionState() = default;
+  std::string serialize() const;
+  std::string get_debug_string() const override;
+  Output default_output_;
 
  private:
-  static VersionedModelId select(BanditPolicyState& state);
+  static Output deserialize(std::string serialized_state);
 };
 
-class Exp4Policy : public SelectionPolicy<Exp4Policy> {
-  // Exp4
-  // Select: all models
-  // Update: update individual model weights (same as Exp3)
-
+class DefaultOutputSelectionPolicy : public SelectionPolicy {
  public:
-  Exp4Policy() = delete;
-  ~Exp4Policy() = delete;
-  typedef BanditPolicyState state_type;
+  DefaultOutputSelectionPolicy() = default;
+  DefaultOutputSelectionPolicy(const DefaultOutputSelectionPolicy&) = default;
+  DefaultOutputSelectionPolicy& operator=(const DefaultOutputSelectionPolicy&) =
+      default;
+  DefaultOutputSelectionPolicy(DefaultOutputSelectionPolicy&&) = default;
+  DefaultOutputSelectionPolicy& operator=(DefaultOutputSelectionPolicy&&) =
+      default;
+  ~DefaultOutputSelectionPolicy() = default;
+  SelectionState init_state(Output default_output) const;
 
-  constexpr static double eta = 0.01;
+  SelectionState update_candidate_models(
+      SelectionState state,
+      const std::vector<VersionedModelId>& candidate_models) const override;
 
-  static BanditPolicyState initialize(
-      const std::vector<VersionedModelId>& candidate_models);
+  std::vector<PredictTask> select_predict_tasks(SelectionState state,
+                                                Query query,
+                                                long query_id) const override;
 
-  static BanditPolicyState add_models(
-      BanditPolicyState state, const std::vector<VersionedModelId>& new_models);
+  Output combine_predictions(const SelectionState& state, Query query,
+                             std::vector<Output> predictions) const override;
 
-  static long hash_models(
-      const std::vector<VersionedModelId>& /*candidate_models*/) {
-    return 0;
-  };
+  std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
+  select_feedback_tasks(const SelectionState& state, FeedbackQuery query,
+                        long query_id) const override;
 
-  static std::vector<PredictTask> select_predict_tasks(BanditPolicyState& state,
-                                                       Query query,
-                                                       long query_id);
+  SelectionState process_feedback(
+      SelectionState state, Feedback feedback,
+      std::vector<Output> predictions) const override;
 
-  static Output combine_predictions(BanditPolicyState state, Query query,
-                                    std::vector<Output> predictions);
-
-  static std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-  select_feedback_tasks(BanditPolicyState& state, FeedbackQuery feedback,
-                        long query_id);
-
-  static BanditPolicyState process_feedback(BanditPolicyState state,
-                                            Feedback feedback,
-                                            std::vector<Output> predictions);
-
-  static std::string serialize_state(BanditPolicyState state);
-
-  static BanditPolicyState deserialize_state(const std::string& bytes);
-
-  static std::string state_debug_string(const BanditPolicyState& state);
+  SelectionState deserialize(std::string serialized_state) const override;
+  std::string serialize(SelectionState state) const override;
 };
 
-class EpsilonGreedyPolicy : public SelectionPolicy<Exp4Policy> {
-  // Epsilon Greedy
-  // Select: epsilon chance randomly select,
-  //         (1-epsilon) change select model with the highest expected reward
-  // Update: update individual model expected reward
-
- public:
-  EpsilonGreedyPolicy() = delete;
-  ~EpsilonGreedyPolicy() = delete;
-  typedef BanditPolicyState state_type;
-
-  constexpr static double epsilon = 0.1;  // Random Selection Chance
-
-  static BanditPolicyState initialize(
-      const std::vector<VersionedModelId>& candidate_models);
-
-  static BanditPolicyState add_models(
-      BanditPolicyState state, const std::vector<VersionedModelId>& new_models);
-
-  static long hash_models(
-      const std::vector<VersionedModelId>& /*candidate_models*/) {
-    return 0;
-  };
-
-  static std::vector<PredictTask> select_predict_tasks(BanditPolicyState& state,
-                                                       Query query,
-                                                       long query_id);
-
-  static Output combine_predictions(BanditPolicyState state, Query query,
-                                    std::vector<Output> predictions);
-
-  static std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-  select_feedback_tasks(BanditPolicyState& state, FeedbackQuery feedback,
-                        long query_id);
-
-  static BanditPolicyState process_feedback(BanditPolicyState state,
-                                            Feedback feedback,
-                                            std::vector<Output> predictions);
-
-  static std::string serialize_state(BanditPolicyState state);
-
-  static BanditPolicyState deserialize_state(const std::string& bytes);
-
-  static std::string state_debug_string(const BanditPolicyState& state);
-
- private:
-  static VersionedModelId select(BanditPolicyState& state);
-};
-
-class UCBPolicy : public SelectionPolicy<UCBPolicy> {
-  // Upper Confidence Bound (UCB1)
-  // Select: highest expected reward upper confidence bound
-  // Update: update individual model expected reward upper confidence bound
-
- public:
-  UCBPolicy() = delete;
-  ~UCBPolicy() = delete;
-  typedef BanditPolicyState state_type;
-
-  static BanditPolicyState initialize(
-      const std::vector<VersionedModelId>& candidate_models);
-
-  static BanditPolicyState add_models(
-      BanditPolicyState state, const std::vector<VersionedModelId>& new_models);
-
-  static long hash_models(
-      const std::vector<VersionedModelId>& /*candidate_models*/) {
-    return 0;
-  };
-
-  static std::vector<PredictTask> select_predict_tasks(BanditPolicyState& state,
-                                                       Query query,
-                                                       long query_id);
-
-  static Output combine_predictions(BanditPolicyState state, Query query,
-                                    std::vector<Output> predictions);
-
-  static std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-  select_feedback_tasks(BanditPolicyState& state, FeedbackQuery feedback,
-                        long query_id);
-
-  static BanditPolicyState process_feedback(BanditPolicyState state,
-                                            Feedback feedback,
-                                            std::vector<Output> predictions);
-
-  static std::string serialize_state(BanditPolicyState state);
-
-  static BanditPolicyState deserialize_state(const std::string& bytes);
-
-  static std::string state_debug_string(const BanditPolicyState& state);
-
- private:
-  static VersionedModelId select(BanditPolicyState& state);
-};
-}
+}  // namespace clipper
 
 #endif  // CLIPPER_LIB_SELECTION_POLICIES_H

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -253,12 +253,12 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
 }
 
 Query::Query(std::string label, long user_id, std::shared_ptr<Input> input,
-             long deadline, std::string selection_policy,
+             long latency_budget_micros, std::string selection_policy,
              std::vector<VersionedModelId> candidate_models)
     : label_(label),
       user_id_(user_id),
       input_(input),
-      deadline_(deadline),
+      latency_budget_micros_(latency_budget_micros),
       selection_policy_(selection_policy),
       candidate_models_(candidate_models),
       create_time_(std::chrono::high_resolution_clock::now()) {}

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -271,12 +271,14 @@ Query::Query(std::string label, long user_id, std::shared_ptr<Input> input,
       candidate_models_(candidate_models),
       create_time_(std::chrono::high_resolution_clock::now()) {}
 
-Response::Response(Query query, QueryId query_id, long duration_micros,
-                   Output output, std::vector<VersionedModelId> models_used)
+Response::Response(Query query, QueryId query_id, const long duration_micros,
+                   Output output, const bool output_is_default,
+                   std::vector<VersionedModelId> models_used)
     : query_(std::move(query)),
       query_id_(query_id),
       duration_micros_(duration_micros),
       output_(std::move(output)),
+      output_is_default_(output_is_default),
       models_used_(models_used) {}
 
 std::string Response::debug_string() const noexcept {

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -65,6 +65,14 @@ InputType parse_input_type(std::string type_string) {
 Output::Output(double y_hat, std::vector<VersionedModelId> models_used)
     : y_hat_(y_hat), models_used_(models_used) {}
 
+bool Output::operator==(const Output &rhs) const {
+  return (y_hat_ == rhs.y_hat_ && models_used_ == rhs.models_used_);
+}
+
+bool Output::operator!=(const Output &rhs) const {
+  return !(y_hat_ == rhs.y_hat_ && models_used_ == rhs.models_used_);
+}
+
 ByteVector::ByteVector(std::vector<uint8_t> data) : data_(std::move(data)) {}
 
 InputType ByteVector::type() const { return InputType::Bytes; }

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -253,12 +253,12 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
 }
 
 Query::Query(std::string label, long user_id, std::shared_ptr<Input> input,
-             long latency_micros, std::string selection_policy,
+             long deadline, std::string selection_policy,
              std::vector<VersionedModelId> candidate_models)
     : label_(label),
       user_id_(user_id),
       input_(input),
-      latency_micros_(latency_micros),
+      deadline_(deadline),
       selection_policy_(selection_policy),
       candidate_models_(candidate_models),
       create_time_(std::chrono::high_resolution_clock::now()) {}

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -237,7 +237,7 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
 
   std::vector<long> inputs_size_bytes;
   // Add the size of the serialized inputs in bytes. This will be
-  // sent prior to the input metadata to allow for proactive
+  // sent prior to the input data to allow for proactive
   // buffer allocation in the receiving container
   inputs_size_bytes.push_back(serialized_inputs.size());
   ByteBuffer serialized_inputs_size = get_byte_buffer(inputs_size_bytes);

--- a/src/libclipper/src/json_util.cpp
+++ b/src/libclipper/src/json_util.cpp
@@ -46,7 +46,17 @@ rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
   return val;
 }
 
-/* Getters with error handling for double, float, long, int, string */
+/* Getters with error handling for boolean, double, float, long, int, string */
+bool get_bool(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
+  if (!v.IsBool()) {
+    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
+        " is not of type double");
+  }
+  return v.GetBool();
+}
+
 double get_double(rapidjson::Value& d, const char* key_name) {
   rapidjson::Value& v =
       check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
@@ -242,6 +252,12 @@ void add_kv_pair(rapidjson::Document& d, const char* key_name,
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
   rapidjson::Value key(key_name, allocator);
   d.AddMember(key, value_to_add, allocator);
+}
+
+void add_bool(rapidjson::Document& d, const char* key_name, bool value_to_add) {
+  rapidjson::Document boolean_doc;
+  boolean_doc.SetBool(value_to_add);
+  add_kv_pair(d, key_name, boolean_doc);
 }
 
 void add_double_array(rapidjson::Document& d, const char* key_name,

--- a/src/libclipper/src/json_util.cpp
+++ b/src/libclipper/src/json_util.cpp
@@ -1,0 +1,327 @@
+
+#include <sstream>
+#include <stdexcept>
+
+#include <rapidjson/document.h>
+#include <rapidjson/error/en.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <clipper/datatypes.hpp>
+#include <clipper/json_util.hpp>
+
+using clipper::Input;
+using clipper::InputType;
+using clipper::Output;
+using clipper::VersionedModelId;
+using rapidjson::Type;
+
+namespace clipper {
+namespace json {
+
+json_parse_error::json_parse_error(const std::string& what)
+    : std::runtime_error(what) {}
+json_parse_error::~json_parse_error() throw(){};
+
+json_semantic_error::json_semantic_error(const std::string& what)
+    : std::runtime_error(what) {}
+json_semantic_error::~json_semantic_error() throw() {}
+
+rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
+                                           const char* key_name,
+                                           Type expected_type) {
+  if (!d.IsObject()) {
+    throw json_semantic_error("Can only get key-value pair from an object");
+  } else if (!d.HasMember(key_name)) {
+    throw json_semantic_error("JSON object does not have required key: " +
+                              std::string(key_name));
+  }
+  rapidjson::Value& val = d[key_name];
+  if (val.GetType() != expected_type) {
+    throw json_semantic_error("Type mismatch! JSON key " +
+                              std::string(key_name) + " expected type " +
+                              kTypeNames[expected_type] + "but found type " +
+                              kTypeNames[val.GetType()]);
+  }
+  return val;
+}
+
+/* Getters with error handling for double, float, long, int, string */
+double get_double(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
+  if (!v.IsDouble()) {
+    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
+                              " is not of type double");
+  }
+  return v.GetDouble();
+}
+
+float get_float(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
+  if (!v.IsFloat()) {
+    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
+                              " is not of type float");
+  }
+  return v.GetFloat();
+}
+
+long get_long(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
+  if (!v.IsInt64()) {
+    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
+                              " is not of type long");
+  }
+  return static_cast<long>(v.GetInt64());
+}
+
+int get_int(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kNumberType);
+  if (!v.IsInt()) {
+    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
+                              " is not of type int");
+  }
+  return v.GetInt();
+}
+
+std::string get_string(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kStringType);
+  if (!v.IsString()) {
+    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
+                              " is not of type string");
+  }
+  return std::string(v.GetString());
+}
+
+/* Getters with error handling for arrays of double, float, int, string */
+std::vector<double> get_double_array(rapidjson::Value& d,
+                                     const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
+  std::vector<double> vals;
+  vals.reserve(v.Capacity());
+  for (rapidjson::Value& elem : v.GetArray()) {
+    if (!elem.IsDouble()) {
+      throw json_semantic_error("Array input of type " +
+                                kTypeNames[elem.GetType()] +
+                                " is not of type double");
+    }
+    vals.push_back(elem.GetDouble());
+  }
+  return vals;
+}
+
+std::vector<float> get_float_array(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
+  std::vector<float> vals;
+  vals.reserve(v.Capacity());
+  for (rapidjson::Value& elem : v.GetArray()) {
+    if (!elem.IsFloat()) {
+      throw json_semantic_error("Array input of type " +
+                                kTypeNames[elem.GetType()] +
+                                " is not of type float");
+    }
+    vals.push_back(elem.GetFloat());
+  }
+  return vals;
+}
+
+std::vector<int> get_int_array(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
+  std::vector<int> vals;
+  vals.reserve(v.Capacity());
+  for (rapidjson::Value& elem : v.GetArray()) {
+    if (!elem.IsInt()) {
+      throw json_semantic_error("Array input of type " +
+                                kTypeNames[elem.GetType()] +
+                                " is not of type int");
+    }
+    vals.push_back(elem.GetInt());
+  }
+  return vals;
+}
+
+std::vector<std::string> get_string_array(rapidjson::Value& d,
+                                          const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
+  std::vector<std::string> vals;
+  vals.reserve(v.Capacity());
+  for (rapidjson::Value& elem : v.GetArray()) {
+    if (!elem.IsString()) {
+      throw json_semantic_error("Array input of type " +
+                                kTypeNames[elem.GetType()] +
+                                " is not of type string");
+    }
+    vals.push_back(elem.GetString());
+  }
+  return vals;
+}
+
+std::vector<VersionedModelId> get_candidate_models(rapidjson::Value& d,
+                                                   const char* key_name) {
+  rapidjson::Value& v =
+      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
+  std::vector<VersionedModelId> candidate_models;
+  candidate_models.reserve(v.Capacity());
+  for (rapidjson::Value& elem : v.GetArray()) {
+    if (!elem.IsObject()) {
+      throw json_semantic_error("Array input of type " +
+                                kTypeNames[elem.GetType()] +
+                                " is not of type Object");
+    } else if (!elem.HasMember("model_name")) {
+      throw json_semantic_error(
+          "Candidate model JSON object missing model_name.");
+    } else if (!elem.HasMember("model_version")) {
+      throw json_semantic_error(
+          "Candidate model JSON object missing model_version.");
+    }
+    std::string model_name = get_string(elem, "model_name");
+    int model_version = get_int(elem, "model_version");
+    candidate_models.push_back(std::make_pair(model_name, model_version));
+  }
+  return candidate_models;
+}
+
+rapidjson::Value& get_object(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& object =
+      check_kv_type_and_return(d, key_name, rapidjson::kObjectType);
+  return object;
+}
+
+void parse_json(const std::string& json_content, rapidjson::Document& d) {
+  rapidjson::ParseResult ok = d.Parse(json_content.c_str());
+  if (!ok) {
+    std::stringstream ss;
+    ss << "JSON parse error: " << rapidjson::GetParseError_En(ok.Code())
+       << " (offset " << ok.Offset() << ")\n";
+    throw json_parse_error(ss.str());
+  }
+}
+
+std::shared_ptr<Input> parse_input(InputType input_type, rapidjson::Value& d) {
+  switch (input_type) {
+    case InputType::Doubles: {
+      std::vector<double> inputs = get_double_array(d, "input");
+      return std::make_shared<clipper::DoubleVector>(inputs);
+    }
+    case InputType::Floats: {
+      std::vector<float> inputs = get_float_array(d, "input");
+      return std::make_shared<clipper::FloatVector>(inputs);
+    }
+    case InputType::Ints: {
+      std::vector<int> inputs = get_int_array(d, "input");
+      return std::make_shared<clipper::IntVector>(inputs);
+    }
+    case InputType::Strings: {
+      std::string input_string = get_string(d, "input");
+      return std::make_shared<clipper::SerializableString>(input_string);
+    }
+    case InputType::Bytes: {
+      throw std::invalid_argument("Base64 encoded bytes are not supported yet");
+    }
+    default: throw std::invalid_argument("input_type is not a valid type");
+  }
+}
+
+/* Utilities for serialization into JSON */
+void add_kv_pair(rapidjson::Document& d, const char* key_name,
+                 rapidjson::Value& value_to_add) {
+  if (!d.IsObject()) {
+    throw json_semantic_error("Can only add a key-value pair to an object");
+  } else if (d.HasMember(key_name)) {
+    // Remove old value associated with key_name
+    d.RemoveMember(key_name);
+  }
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  rapidjson::Value key(key_name, allocator);
+  d.AddMember(key, value_to_add, allocator);
+}
+
+void add_double_array(rapidjson::Document& d, const char* key_name,
+                      std::vector<double>& values_to_add) {
+  rapidjson::Value double_array(rapidjson::kArrayType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  for (std::size_t i = 0; i < values_to_add.size(); i++) {
+    double_array.PushBack(values_to_add[i], allocator);
+  }
+  add_kv_pair(d, key_name, double_array);
+}
+
+void add_float_array(rapidjson::Document& d, const char* key_name,
+                     std::vector<float>& values_to_add) {
+  rapidjson::Value float_array(rapidjson::kArrayType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  for (std::size_t i = 0; i < values_to_add.size(); i++) {
+    float_array.PushBack(values_to_add[i], allocator);
+  }
+  add_kv_pair(d, key_name, float_array);
+}
+
+void add_int_array(rapidjson::Document& d, const char* key_name,
+                   std::vector<int>& values_to_add) {
+  rapidjson::Value int_array(rapidjson::kArrayType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  for (std::size_t i = 0; i < values_to_add.size(); i++) {
+    int_array.PushBack(values_to_add[i], allocator);
+  }
+  add_kv_pair(d, key_name, int_array);
+}
+
+void add_string_array(rapidjson::Document& d, const char* key_name,
+                      std::vector<std::string>& values_to_add) {
+  rapidjson::Value string_array(rapidjson::kArrayType);
+  rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+  for (std::size_t i = 0; i < values_to_add.size(); i++) {
+    rapidjson::Value string_val(values_to_add[i].c_str(), allocator);
+    string_array.PushBack(string_val, allocator);
+  }
+  add_kv_pair(d, key_name, string_array);
+}
+
+void add_double(rapidjson::Document& d, const char* key_name, double val) {
+  rapidjson::Value val_to_add(val);
+  add_kv_pair(d, key_name, val_to_add);
+}
+
+void add_float(rapidjson::Document& d, const char* key_name, float val) {
+  rapidjson::Value val_to_add(val);
+  add_kv_pair(d, key_name, val_to_add);
+}
+
+void add_int(rapidjson::Document& d, const char* key_name, int val) {
+  rapidjson::Value val_to_add(val);
+  add_kv_pair(d, key_name, val_to_add);
+}
+
+void add_long(rapidjson::Document& d, const char* key_name, long val) {
+  rapidjson::Value val_to_add((int64_t)val);
+  add_kv_pair(d, key_name, val_to_add);
+}
+
+void add_string(rapidjson::Document& d, const char* key_name,
+                const std::string& val) {
+  rapidjson::Value val_to_add(val.c_str(), d.GetAllocator());
+  add_kv_pair(d, key_name, val_to_add);
+}
+
+void add_object(rapidjson::Document& d, const char* key_name,
+                rapidjson::Document& to_add) {
+  add_kv_pair(d, key_name, to_add);
+}
+
+std::string to_json_string(rapidjson::Document& d) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  d.Accept(writer);
+  return buffer.GetString();
+}
+
+}  // namespace json
+}  // namespace clipper

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -52,9 +52,7 @@ boost::future<Response> QueryProcessor::predict(Query query) {
   }
   std::shared_ptr<SelectionPolicy> current_policy = current_policy_iter->second;
 
-  auto hashkey = current_policy->hash_models(query.candidate_models_);
-  auto state_opt =
-      state_db_->get(StateKey{query.label_, query.user_id_, hashkey});
+  auto state_opt = state_db_->get(StateKey{query.label_, query.user_id_, 0});
   if (!state_opt) {
     log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
                         "No selection state found for query with label: {}",
@@ -146,9 +144,8 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
   }
   std::shared_ptr<SelectionPolicy> current_policy = current_policy_iter->second;
 
-  auto hashkey = current_policy->hash_models(feedback.candidate_models_);
   auto state_opt =
-      state_db_->get(StateKey{feedback.label_, feedback.user_id_, hashkey});
+      state_db_->get(StateKey{feedback.label_, feedback.user_id_, 0});
   if (!state_opt) {
     log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
                         "No selection state found for query with label: {}",

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -1,4 +1,3 @@
-
 #include <cassert>
 #include <chrono>
 #include <iomanip>
@@ -27,71 +26,10 @@ using std::tuple;
 
 namespace clipper {
 
-// TODO: replace these template methods with a better way to do
-// polymorphic dispatch
-template <typename Policy>
-std::pair<std::vector<PredictTask>, std::string> select_predict_tasks(
-    Query query, long query_id, std::shared_ptr<StateDB> state_db) {
-  auto hashkey = Policy::hash_models(query.candidate_models_);
-  typename Policy::state_type state;
-  std::string serialized_state;
-  if (auto state_opt =
-          state_db->get(StateKey{query.label_, query.user_id_, hashkey})) {
-    serialized_state = *state_opt;
-    // if auto doesn't work: Policy::state_type
-    state = Policy::deserialize_state(serialized_state);
-  } else {
-    state = Policy::initialize(query.candidate_models_);
-    serialized_state = Policy::serialize_state(state);
-  }
-  return std::make_pair(Policy::select_predict_tasks(state, query, query_id),
-                        serialized_state);
-}
-
-template <typename Policy>
-Output combine_predictions(Query query, std::vector<Output> predictions,
-                           const std::string& serialized_state) {
-  // typename Policy::state_type state;
-  const auto state = Policy::deserialize_state(serialized_state);
-  return Policy::combine_predictions(state, query, predictions);
-}
-
-template <typename Policy>
-std::pair<std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>,
-          std::string>
-select_feedback_tasks(FeedbackQuery query, long query_id,
-                      std::shared_ptr<StateDB> state_db) {
-  auto hashkey = Policy::hash_models(query.candidate_models_);
-  typename Policy::state_type state;
-  std::string serialized_state;
-  if (auto state_opt =
-          state_db->get(StateKey{query.label_, query.user_id_, hashkey})) {
-    serialized_state = *state_opt;
-    // if auto doesn't work: Policy::state_type
-    state = Policy::deserialize_state(serialized_state);
-  } else {
-    state = Policy::initialize(query.candidate_models_);
-    serialized_state = Policy::serialize_state(state);
-  }
-  return std::make_pair(Policy::select_feedback_tasks(state, query, query_id),
-                        serialized_state);
-}
-
-template <typename Policy>
-void process_feedback(FeedbackQuery feedback, std::vector<Output> predictions,
-                      const std::string& serialized_state,
-                      std::shared_ptr<StateDB> state_db) {
-  // typename Policy::state_type state;
-  const auto state = Policy::deserialize_state(serialized_state);
-  auto new_state =
-      Policy::process_feedback(state, feedback.feedback_, predictions);
-  auto serialized_new_state = Policy::serialize_state(new_state);
-  auto hashkey = Policy::hash_models(feedback.candidate_models_);
-  state_db->put(StateKey{feedback.label_, feedback.user_id_, hashkey},
-                serialized_new_state);
-}
-
 QueryProcessor::QueryProcessor() : state_db_(std::make_shared<StateDB>()) {
+  // Create selection policy instances
+  selection_policies_.emplace("DefaultOutputSelectionPolicy",
+                              std::make_shared<DefaultOutputSelectionPolicy>());
   log_info(LOGGING_TAG_QUERY_PROCESSOR, "Query Processor started");
 }
 
@@ -101,48 +39,42 @@ std::shared_ptr<StateDB> QueryProcessor::get_state_table() const {
 
 boost::future<Response> QueryProcessor::predict(Query query) {
   long query_id = query_counter_.fetch_add(1);
-  std::vector<PredictTask> tasks;
-  std::string serialized_state;
-
-  if (query.selection_policy_ == "EXP3") {
-    auto tasks_and_state =
-        select_predict_tasks<Exp3Policy>(query, query_id, get_state_table());
-    tasks = tasks_and_state.first;
-    serialized_state = tasks_and_state.second;
-
-  } else if (query.selection_policy_ == "EXP4") {
-    auto tasks_and_state =
-        select_predict_tasks<Exp4Policy>(query, query_id, get_state_table());
-    tasks = tasks_and_state.first;
-    serialized_state = tasks_and_state.second;
-
-  } else if (query.selection_policy_ == "EpsilonGreedy") {
-    auto tasks_and_state = select_predict_tasks<EpsilonGreedyPolicy>(
-        query, query_id, get_state_table());
-    tasks = tasks_and_state.first;
-    serialized_state = tasks_and_state.second;
-
-  } else if (query.selection_policy_ == "UCB") {
-    auto tasks_and_state =
-        select_predict_tasks<UCBPolicy>(query, query_id, get_state_table());
-    tasks = tasks_and_state.first;
-    serialized_state = tasks_and_state.second;
-  } else {
+  boost::future<Response> error_response =
+      boost::make_ready_future(Response{query, query_id, 20000, Output{1.0, {}},
+                                        std::vector<VersionedModelId>()});
+  auto current_policy_iter = selection_policies_.find(query.selection_policy_);
+  if (current_policy_iter == selection_policies_.end()) {
     log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
                         "{} is an invalid selection policy",
                         query.selection_policy_);
     // TODO better error handling
-    return boost::make_ready_future(
-        Response{query, query_id, 20000, Output{1.0, {std::make_pair("m1", 1)}},
-                 std::vector<VersionedModelId>()});
+    return error_response;
   }
+  std::shared_ptr<SelectionPolicy> current_policy = current_policy_iter->second;
+
+  auto hashkey = current_policy->hash_models(query.candidate_models_);
+  auto state_opt =
+      state_db_->get(StateKey{query.label_, query.user_id_, hashkey});
+  if (!state_opt) {
+    log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
+                        "No selection state found for query with label: {}",
+                        query.label_);
+    // TODO better error handling
+    return error_response;
+  }
+  std::shared_ptr<SelectionState> selection_state =
+      current_policy->deserialize(*state_opt);
+
+  std::vector<PredictTask> tasks =
+      current_policy->select_predict_tasks(selection_state, query, query_id);
+
   log_info_formatted(LOGGING_TAG_QUERY_PROCESSOR, "Found {} tasks",
                      tasks.size());
 
   vector<boost::future<Output>> task_futures =
       task_executor_.schedule_predictions(tasks);
   boost::future<void> timer_future =
-      timer_system_.set_timer(query.latency_micros_);
+      timer_system_.set_timer(query.latency_budget_micros_);
 
   // vector<boost::future<Output>> task_completion_futures;
 
@@ -168,8 +100,8 @@ boost::future<Response> QueryProcessor::predict(Query query) {
   // so that they outlive the composed_futures.
   response_ready_future.then([
     query, query_id, response_promise = std::move(response_promise),
-    serialized_state = std::move(serialized_state),
-    task_futures = std::move(task_futures), num_completed, completed_flag
+    selection_state, current_policy, task_futures = std::move(task_futures),
+    num_completed, completed_flag
   ](auto) mutable {
 
     vector<Output> outputs;
@@ -180,25 +112,8 @@ boost::future<Response> QueryProcessor::predict(Query query) {
       }
     }
 
-    Output final_output;
-
-    if (query.selection_policy_ == "EXP3") {
-      final_output =
-          combine_predictions<Exp3Policy>(query, outputs, serialized_state);
-
-    } else if (query.selection_policy_ == "EXP4") {
-      final_output =
-          combine_predictions<Exp4Policy>(query, outputs, serialized_state);
-    } else if (query.selection_policy_ == "EpsilonGreedy") {
-      final_output = combine_predictions<EpsilonGreedyPolicy>(query, outputs,
-                                                              serialized_state);
-
-    } else if (query.selection_policy_ == "UCB") {
-      final_output =
-          combine_predictions<UCBPolicy>(query, outputs, serialized_state);
-    } else {
-      UNREACHABLE();
-    }
+    Output final_output =
+        current_policy->combine_predictions(selection_state, query, outputs);
     std::chrono::time_point<std::chrono::high_resolution_clock> end =
         std::chrono::high_resolution_clock::now();
     long duration_micros =
@@ -209,7 +124,6 @@ boost::future<Response> QueryProcessor::predict(Query query) {
     Response response{query, query_id, duration_micros, final_output,
                       query.candidate_models_};
     response_promise.set_value(response);
-
   });
   return response_future;
 }
@@ -219,47 +133,38 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
            feedback.user_id_);
 
   long query_id = query_counter_.fetch_add(1);
-  std::vector<PredictTask> predict_tasks;
-  std::vector<FeedbackTask> feedback_tasks;
-  std::string serialized_state;
+  boost::future<FeedbackAck> error_response = boost::make_ready_future(false);
 
-  if (feedback.selection_policy_ == "EXP3") {
-    auto tasks_and_state = select_feedback_tasks<Exp3Policy>(feedback, query_id,
-                                                             get_state_table());
-    // TODO: clean this up
-    predict_tasks = tasks_and_state.first.first;
-    feedback_tasks = tasks_and_state.first.second;
-    serialized_state = tasks_and_state.second;
-
-  } else if (feedback.selection_policy_ == "EXP4") {
-    auto tasks_and_state = select_feedback_tasks<Exp4Policy>(feedback, query_id,
-                                                             get_state_table());
-    // TODO: clean this up
-    predict_tasks = tasks_and_state.first.first;
-    feedback_tasks = tasks_and_state.first.second;
-    serialized_state = tasks_and_state.second;
-  } else if (feedback.selection_policy_ == "EpsilonGreedy") {
-    auto tasks_and_state = select_feedback_tasks<EpsilonGreedyPolicy>(
-        feedback, query_id, get_state_table());
-    // TODO: clean this up
-    predict_tasks = tasks_and_state.first.first;
-    feedback_tasks = tasks_and_state.first.second;
-    serialized_state = tasks_and_state.second;
-
-  } else if (feedback.selection_policy_ == "UCB") {
-    auto tasks_and_state =
-        select_feedback_tasks<UCBPolicy>(feedback, query_id, get_state_table());
-    // TODO: clean this up
-    predict_tasks = tasks_and_state.first.first;
-    feedback_tasks = tasks_and_state.first.second;
-    serialized_state = tasks_and_state.second;
-  } else {
+  auto current_policy_iter =
+      selection_policies_.find(feedback.selection_policy_);
+  if (current_policy_iter == selection_policies_.end()) {
     log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
-                        "{} is an invalid feedback selection policy",
+                        "{} is an invalid selection policy",
                         feedback.selection_policy_);
     // TODO better error handling
-    return boost::make_ready_future(false);
+    return error_response;
   }
+  std::shared_ptr<SelectionPolicy> current_policy = current_policy_iter->second;
+
+  auto hashkey = current_policy->hash_models(feedback.candidate_models_);
+  auto state_opt =
+      state_db_->get(StateKey{feedback.label_, feedback.user_id_, hashkey});
+  if (!state_opt) {
+    log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
+                        "No selection state found for query with label: {}",
+                        feedback.label_);
+    // TODO better error handling
+    return error_response;
+  }
+  std::shared_ptr<SelectionState> selection_state =
+      current_policy->deserialize(*state_opt);
+
+  std::vector<PredictTask> predict_tasks;
+  std::vector<FeedbackTask> feedback_tasks;
+  std::tie(predict_tasks, feedback_tasks) =
+      current_policy->select_feedback_tasks(selection_state, feedback,
+                                            query_id);
+
   log_info_formatted(LOGGING_TAG_QUERY_PROCESSOR,
                      "Scheduling {} prediction tasks and {} feedback tasks",
                      predict_tasks.size(), feedback_tasks.size());
@@ -275,8 +180,6 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
   vector<boost::future<FeedbackAck>> feedback_task_futures =
       task_executor_.schedule_feedback(std::move(feedback_tasks));
 
-  // TODO: replace with clipper::future implementation of when_all
-  // when this future completes, we are ready to update the selection state
   boost::future<void> all_preds_completed;
   auto num_preds_completed = std::make_shared<std::atomic<int>>(0);
   std::tie(all_preds_completed, predict_task_futures) =
@@ -290,39 +193,21 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
   // This promise gets completed after selection policy state update has
   // finished.
   boost::promise<FeedbackAck> select_policy_update_promise;
-  auto state_db_ptr = get_state_table();
+  auto state_table = get_state_table();
   auto select_policy_updated = select_policy_update_promise.get_future();
   all_preds_completed.then([
-    moved_promise = std::move(select_policy_update_promise),
-    moved_serialized_state = std::move(serialized_state),
-    state_table = std::move(state_db_ptr), feedback, query_id,
+    moved_promise = std::move(select_policy_update_promise), selection_state,
+    current_policy, state_table, feedback, query_id,
     predict_task_futures = std::move(predict_task_futures)
   ](auto) mutable {
-    // auto pred_futures = pred_tasks_future.get();
 
     std::vector<Output> preds;
     // collect actual predictions from their futures
     for (auto& r : predict_task_futures) {
       preds.push_back(r.get());
     }
-
-    if (feedback.selection_policy_ == "EXP3") {
-      process_feedback<Exp3Policy>(feedback, preds, moved_serialized_state,
-                                   state_table);
-
-    } else if (feedback.selection_policy_ == "EXP4") {
-      process_feedback<Exp4Policy>(feedback, preds, moved_serialized_state,
-                                   state_table);
-    } else if (feedback.selection_policy_ == "EpsilonGreedy") {
-      process_feedback<EpsilonGreedyPolicy>(
-          feedback, preds, moved_serialized_state, state_table);
-
-    } else if (feedback.selection_policy_ == "UCB") {
-      process_feedback<UCBPolicy>(feedback, preds, moved_serialized_state,
-                                  state_table);
-    } else {
-      UNREACHABLE();
-    }
+    current_policy->process_feedback(selection_state, feedback.feedback_,
+                                     preds);
     moved_promise.set_value(true);
   });
 
@@ -339,9 +224,6 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
         select_policy_updated = std::move(select_policy_updated),
         feedback_task_futures = std::move(feedback_task_futures)
       ](auto) mutable {
-        // check that all feedback was successful
-        // auto result = f.get();
-        // auto feedback_results = std::get<0>(result).get();
         auto select_policy_update_result = select_policy_updated.get();
         if (!select_policy_update_result) {
           return false;

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -28,7 +28,7 @@ namespace clipper {
 
 QueryProcessor::QueryProcessor() : state_db_(std::make_shared<StateDB>()) {
   // Create selection policy instances
-  selection_policies_.emplace("DefaultOutputSelectionPolicy",
+  selection_policies_.emplace(DefaultOutputSelectionPolicy::get_name(),
                               std::make_shared<DefaultOutputSelectionPolicy>());
   log_info(LOGGING_TAG_QUERY_PROCESSOR, "Query Processor started");
 }

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -144,8 +144,8 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
   }
   std::shared_ptr<SelectionPolicy> current_policy = current_policy_iter->second;
 
-  auto state_opt =
-      state_db_->get(StateKey{feedback.label_, feedback.user_id_, 0});
+  StateKey state_key{feedback.label_, feedback.user_id_, 0};
+  auto state_opt = state_db_->get(state_key);
   if (!state_opt) {
     log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
                         "No selection state found for query with label: {}",
@@ -194,7 +194,7 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
   auto select_policy_updated = select_policy_update_promise.get_future();
   all_preds_completed.then([
     moved_promise = std::move(select_policy_update_promise), selection_state,
-    current_policy, state_table, feedback, query_id,
+    current_policy, state_table, feedback, query_id, state_key,
     predict_task_futures = std::move(predict_task_futures)
   ](auto) mutable {
 
@@ -203,8 +203,9 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
     for (auto& r : predict_task_futures) {
       preds.push_back(r.get());
     }
-    current_policy->process_feedback(selection_state, feedback.feedback_,
-                                     preds);
+    auto new_selection_state = current_policy->process_feedback(
+        selection_state, feedback.feedback_, preds);
+    state_table->put(state_key, current_policy->serialize(new_selection_state));
     moved_promise.set_value(true);
   });
 

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -53,19 +53,22 @@ boost::future<Response> QueryProcessor::predict(Query query) {
   long query_id = query_counter_.fetch_add(1);
   auto current_policy_iter = selection_policies_.find(query.selection_policy_);
   if (current_policy_iter == selection_policies_.end()) {
-    std::stringstream err_msg;
-    err_msg << query.selection_policy_ << " " << "is an invalid selection_policy.";
-    log_error(LOGGING_TAG_QUERY_PROCESSOR, err_msg.str());
-    throw new PredictError(query_id, err_msg.str());
+    std::stringstream err_msg_builder;
+    err_msg_builder << query.selection_policy_ << " " << "is an invalid selection_policy.";
+    const std::string err_msg = err_msg_builder.str();
+    log_error(LOGGING_TAG_QUERY_PROCESSOR, err_msg);
+    throw PredictError(query_id, err_msg);
   }
   std::shared_ptr<SelectionPolicy> current_policy = current_policy_iter->second;
 
   auto state_opt = state_db_->get(StateKey{query.label_, query.user_id_, 0});
   if (!state_opt) {
-    std::stringstream err_msg;
-    err_msg << "No selection state found for query with label: " << query.label_;
-    log_error(LOGGING_TAG_QUERY_PROCESSOR, err_msg.str());
-    throw new PredictError(query_id, err_msg.str());
+    std::stringstream err_msg_builder;
+    err_msg_builder << "No selection state found for query with user_id: " << query.user_id_
+            << " and label: " << query.label_;
+    const std::string err_msg = err_msg_builder.str();
+    log_error(LOGGING_TAG_QUERY_PROCESSOR, err_msg);
+    throw PredictError(query_id, err_msg);
   }
   std::shared_ptr<SelectionState> selection_state =
       current_policy->deserialize(*state_opt);

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -259,6 +259,7 @@ unordered_map<string, string> get_container_by_key(Redox& redis,
 bool add_application(redox::Redox& redis, const std::string& appname,
                      const std::vector<VersionedModelId>& models,
                      const InputType& input_type, const std::string& policy,
+                     const std::string& default_output,
                      const long latency_slo_micros) {
   if (send_cmd_no_reply<string>(
           redis, {"SELECT", std::to_string(REDIS_APPLICATION_DB_NUM)})) {
@@ -270,6 +271,8 @@ bool add_application(redox::Redox& redis, const std::string& appname,
                                  get_readable_input_type(input_type),
                                  "policy",
                                  policy,
+                                 "default_output",
+                                 default_output,
                                  "latency_slo_micros",
                                  std::to_string(latency_slo_micros)};
     return send_cmd_no_reply<string>(redis, cmd_vec);

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -54,6 +54,8 @@ std::string gen_versioned_model_key(const VersionedModelId& key) {
 }
 
 string labels_to_str(const vector<string>& labels) {
+  if (labels.empty()) return "";
+
   std::ostringstream ss;
   for (auto l = labels.begin(); l != labels.end() - 1; ++l) {
     ss << *l << ITEM_DELIMITER;
@@ -80,6 +82,8 @@ vector<string> str_to_labels(const string& label_str) {
 }
 
 std::string models_to_str(const std::vector<VersionedModelId>& models) {
+  if (models.empty()) return "";
+
   std::ostringstream ss;
   for (auto m = models.begin(); m != models.end() - 1; ++m) {
     ss << m->first << ITEM_PART_CONCATENATOR << m->second << ITEM_DELIMITER;

--- a/src/libclipper/src/selection_policies.cpp
+++ b/src/libclipper/src/selection_policies.cpp
@@ -73,7 +73,7 @@ std::vector<PredictTask> DefaultOutputSelectionPolicy::select_predict_tasks(
 }
 
 Output DefaultOutputSelectionPolicy::combine_predictions(
-    const std::shared_ptr<SelectionState>& state, Query query,
+    const std::shared_ptr<SelectionState>& state, Query /*query*/,
     std::vector<Output> predictions) const {
   if (predictions.size() == 1) {
     return predictions.front();
@@ -105,7 +105,7 @@ std::shared_ptr<SelectionState> DefaultOutputSelectionPolicy::process_feedback(
 
 std::shared_ptr<SelectionState> DefaultOutputSelectionPolicy::deserialize(
     std::string serialized_state) const {
-  return DefaultOutputSelectionState(serialized_state);
+  return std::make_shared<DefaultOutputSelectionState>(serialized_state);
 }
 
 std::string DefaultOutputSelectionPolicy::serialize(

--- a/src/libclipper/src/selection_policies.cpp
+++ b/src/libclipper/src/selection_policies.cpp
@@ -1,569 +1,134 @@
-#include <float.h>
-#include <math.h>
-#include <time.h>
+// #include <float.h>
+// #include <math.h>
+// #include <time.h>
 #include <functional>
 #include <iostream>
-#include <random>
+// #include <random>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
-#include <boost/serialization/string.hpp>
-#include <boost/serialization/unordered_map.hpp>
-#include <boost/serialization/utility.hpp>
+// #include <boost/archive/binary_iarchive.hpp>
+// #include <boost/archive/binary_oarchive.hpp>
+// #include <boost/serialization/string.hpp>
+// #include <boost/serialization/unordered_map.hpp>
+// #include <boost/serialization/utility.hpp>
+
+#include <rapidjson/document.h>
 
 #include <clipper/datatypes.hpp>
+#include <clipper/json_util.hpp>
 #include <clipper/logging.hpp>
 #include <clipper/selection_policies.hpp>
 #include <clipper/util.hpp>
 
 namespace clipper {
 
-// *********
-// * State *
-// *********
+// DefaultOutputSelectionState
 
-void BanditPolicyState::set_model_map(Map map) { model_map_ = map; }
-void BanditPolicyState::add_model(VersionedModelId id, ModelInfo model) {
-  model_map_.insert({id, model});
+DefaultOutputSelectionState::DefaultOutputSelectionState(Output default_output)
+    : default_output_(default_output) {}
+
+DefaultOutputSelectionState::DefaultOutputSelectionState(
+    std::string serialized_state)
+    : default_output_(deserialize(serialized_state)) {}
+
+std::string DefaultOutputSelectionState::serialize() const {
+  rapidjson::Document d;
+  d.SetObject();
+  json::add_double(d, "y_hat", default_output_.y_hat_);
+  return json::to_json_string(d);
 }
-void BanditPolicyState::set_weight_sum(double sum) { weight_sum_ = sum; }
-
-std::string BanditPolicyState::serialize() const {
-  std::stringstream ss;
-  boost::archive::binary_oarchive oa(ss);
-  oa << weight_sum_ << model_map_.size()
-     << model_map_;  // save weight_sum, map size and map
-  return ss.str();
+std::string DefaultOutputSelectionState::get_debug_string() const {
+  rapidjson::Document d;
+  d.SetObject();
+  json::add_double(d, "y_hat", default_output_.y_hat_);
+  std::vector<std::string> empty_vec;
+  json::add_string_array(d, "models_used", empty_vec);
+  return json::to_json_string(d);
 }
 
-BanditPolicyState BanditPolicyState::deserialize(const std::string& bytes) {
-  std::stringstream ss;
-  ss.str(bytes);
-  boost::archive::binary_iarchive ia(ss);
-  BanditPolicyState state;
-  double sum;
-  size_t size;
-  ia >> sum >> size;  // load weight_sum and map size
-  Map map(size, &versioned_model_hash);
-  ia >> map;
-  state.set_model_map(map);
-  state.set_weight_sum(sum);
+Output DefaultOutputSelectionState::deserialize(std::string serialized_state) {
+  rapidjson::Document d;
+  json::parse_json(serialized_state, d);
+  return Output(json::get_double(d, "y_hat"), {});
+}
 
+///////////////////// DefaultOutputSelectionPolicy ////////////////////
+
+SelectionState DefaultOutputSelectionPolicy::init_state(
+    Output default_output) const {
+  return DefaultOutputSelectionState(default_output);
+}
+
+SelectionState DefaultOutputSelectionPolicy::update_candidate_models(
+    SelectionState state,
+    const std::vector<VersionedModelId>& candidate_models) const {
   return state;
 }
 
-std::string BanditPolicyState::debug_string() const {
-  /** State string representation:
-    *  For each model: Model Name, Model ID, Model Property Value 1, Model
-   * Property Value 2
-    *  Different models are separated by semi-colon
-    *  e.g. "3.0;classification,00001,1.0,0.4;regression,203422,1.0,0.4;......."
-    */
-
-  std::string string_state = "Exp3State;";
-  if (model_map_.empty()) {
-    std::cout << "State is empty" << std::endl;
-    return string_state;
-  }
-  string_state += std::to_string(weight_sum_) + ";";  // Weight Sum
-  for (auto it : model_map_) {
-    string_state +=
-        it.first.first + std::to_string(it.first.second);  // Model Name
-    for (auto model_info_it : it.second) {                 // Model information
-      string_state += "," + std::to_string(model_info_it.second);
-    }
-    string_state += ";";
-  }
-  return string_state;
-}
-
-// ********
-// * EXP3 *
-// ********
-
-BanditPolicyState Exp3Policy::initialize(
-    const std::vector<VersionedModelId>& candidate_models_) {
-  Map map(candidate_models_.size(), &versioned_model_hash);
-  for (VersionedModelId id : candidate_models_) {
-    ModelInfo info = {{"weight", 1.0}};
-    map.insert({id, info});
-  }
-  BanditPolicyState state;
-  state.set_model_map(map);
-  state.set_weight_sum(map.size() * 1.0);
-  return state;
-}
-
-BanditPolicyState Exp3Policy::add_models(
-    BanditPolicyState state, const std::vector<VersionedModelId>& new_models) {
-  double avg;
-  if (state.model_map_.empty()) {  // State hasn't been initiated or no models
-    avg = 1.0;
-  } else {
-    avg = state.weight_sum_ / state.model_map_.size();
-  }
-
-  for (VersionedModelId id : new_models) {
-    ModelInfo info = {{"weight", avg}};
-    state.add_model(id, info);
-    state.set_weight_sum(state.weight_sum_ + avg);
-  }
-  return state;
-}
-
-VersionedModelId Exp3Policy::select(BanditPolicyState& state) {
-  // Helper function for randomly drawing an arm based on its normalized weight
-  VersionedModelId selected_model;
-  if (state.model_map_.empty()) {
-    std::cout << "No models to select from" << std::endl;
-    return selected_model;
-  }
-  double rand_num =
-      (double)rand() / (RAND_MAX);  // Pick random number between [0, 1]
-  for (auto it = state.model_map_.begin();
-       it != state.model_map_.end() && rand_num >= 0; ++it) {
-    rand_num -= it->second["weight"] / state.weight_sum_;
-    selected_model = it->first;
-  }
-  return selected_model;
-}
-
-std::vector<PredictTask> Exp3Policy::select_predict_tasks(
-    BanditPolicyState state, Query query, long query_id) {
-  auto selected_model = select(state);
-  auto task = PredictTask(query.input_, selected_model, 1.0, query_id,
-                          query.latency_micros_);
-  std::vector<PredictTask> tasks{task};
-  return tasks;
-}
-
-Output Exp3Policy::combine_predictions(BanditPolicyState /*state*/,
-                                       Query /*query*/,
-                                       std::vector<Output> predictions) {
-  if (predictions.empty()) {
-    std::cout << "No predictions to combine" << std::endl;
-    return Output(0.0, {});
-  }
-  return predictions.front();
-}
-
-std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-Exp3Policy::select_feedback_tasks(BanditPolicyState& state,
-                                  FeedbackQuery feedback, long query_id) {
-  // Predict Task
-  auto selected_model = select(state);
-  auto predict_task =
-      PredictTask(feedback.feedback_.input_, selected_model, -1, query_id, -1);
-  std::vector<PredictTask> predict_tasks{predict_task};
-  // Feedback Task
-  std::vector<FeedbackTask> feedback_tasks;
-
-  return make_pair(predict_tasks, feedback_tasks);
-}
-
-BanditPolicyState Exp3Policy::process_feedback(
-    BanditPolicyState state, Feedback feedback,
-    std::vector<Output> predictions) {
-  if (predictions.empty()) {  // Edge case
-    std::cout << "No predictions, so can't update state." << std::endl;
-    return state;
-  }
-
-  // Compute loss and find which model to update
-  auto loss = std::abs(predictions.front().y_hat_ - feedback.y_);
-  auto model_id = predictions.front().models_used_.front();
-  // Update arm weight and weight_sum
-  auto s_i = state.model_map_[model_id]["weight"];
-  if (s_i != 0) {
-    auto update = exp(-eta * loss / (s_i / state.weight_sum_));
-    state.model_map_[model_id]["weight"] = s_i * update;
-    state.set_weight_sum(state.weight_sum_ - s_i +
-                         state.model_map_[model_id]["weight"]);
-  }
-  return state;
-}
-
-std::string Exp3Policy::serialize_state(BanditPolicyState state) {
-  return state.serialize();
-}
-
-BanditPolicyState Exp3Policy::deserialize_state(const std::string& bytes) {
-  return BanditPolicyState::deserialize(bytes);
-}
-
-std::string Exp3Policy::state_debug_string(const BanditPolicyState& state) {
-  return state.debug_string();
-}
-
-//// ********
-//// * EXP4 *
-//// ********
-
-BanditPolicyState Exp4Policy::initialize(
-    const std::vector<VersionedModelId>& candidate_models_) {
-  Map map(candidate_models_.size(), &versioned_model_hash);
-  for (VersionedModelId id : candidate_models_) {
-    ModelInfo info = {{"weight", 1.0}};
-    map.insert({id, info});
-  }
-  BanditPolicyState state;
-  state.set_model_map(map);
-  state.set_weight_sum(map.size() * 1.0);
-  return state;
-}
-
-BanditPolicyState Exp4Policy::add_models(
-    BanditPolicyState state, const std::vector<VersionedModelId>& new_models) {
-  double avg;
-  if (state.model_map_.empty()) {  // State hasn't been initiated or no models
-    avg = 1.0;
-  } else {
-    avg = state.weight_sum_ / state.model_map_.size();
-  }
-
-  for (VersionedModelId id : new_models) {
-    ModelInfo info = {{"weight", avg}};
-    state.add_model(id, info);
-    state.set_weight_sum(state.weight_sum_ + avg);
-  }
-  return state;
-}
-
-std::vector<PredictTask> Exp4Policy::select_predict_tasks(
-    BanditPolicyState& /*state*/, Query query, long query_id) {
-  // Pass along all models selected
+std::vector<PredictTask> DefaultOutputSelectionPolicy::select_predict_tasks(
+    SelectionState /*state*/, Query query, long query_id) const {
   std::vector<PredictTask> tasks;
-  for (VersionedModelId id : query.candidate_models_) {
-    auto task =
-        PredictTask(query.input_, id, 1.0, query_id, query.latency_micros_);
-    tasks.push_back(task);
-  }
-  return tasks;
-}
-
-Output Exp4Policy::combine_predictions(BanditPolicyState state, Query /*query*/,
-                                       std::vector<Output> predictions) {
-  // Weighted Combination of All predictions
-  double score_sum = 0.0;
-  double weight_sum = 0.0;
-  std::vector<VersionedModelId> models;
-  for (auto p : predictions) {
-    auto model_id = (p.models_used_).front();
-    score_sum += state.model_map_[model_id]["weight"] * p.y_hat_;
-    weight_sum += state.model_map_[model_id]["weight"];
-    models.push_back(model_id);
-  }
-
-  double y_hat = score_sum / weight_sum;
-  // Turn y_hat into either 0 or 1
-  if (y_hat < 0.5) {
-    y_hat = 0.0;
+  int num_candidate_models = query.candidate_models_.size();
+  if (num_candidate_models == 0) {
+    log_error_formatted(LOGGING_TAG_SELECTION_POLICY,
+                        "No candidate models for query with label {}",
+                        query.label_);
+  } else if (num_candidate_models == 1) {
+    tasks.emplace_back(query.input_, query.candidate_models_.front(), 1.0,
+                       query_id, query.deadline_);
   } else {
-    y_hat = 1.0;
+    log_error_formatted(LOGGING_TAG_SELECTION_POLICY,
+                        "{} candidate models provided for query with label "
+                        "{}. Picking the first one.",
+                        num_candidate_models, query.label_);
+    tasks.emplace_back(query.input_, query.candidate_models_.front(), 1.0,
+                       query_id, query.deadline_);
   }
-
-  auto output = Output(y_hat, models);
-  return output;
-}
-
-std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-Exp4Policy::select_feedback_tasks(BanditPolicyState& /*state*/,
-                                  FeedbackQuery feedback, long query_id) {
-  std::vector<PredictTask> predict_tasks;
-  std::vector<FeedbackTask> feedback_tasks;
-  for (VersionedModelId id : feedback.candidate_models_) {
-    auto predict_task =
-        PredictTask(feedback.feedback_.input_, id, -1, query_id, -1);
-    predict_tasks.push_back(predict_task);
-  }
-  return std::make_pair(predict_tasks, feedback_tasks);
-}
-
-BanditPolicyState Exp4Policy::process_feedback(
-    BanditPolicyState state, Feedback feedback,
-    std::vector<Output> predictions) {
-  if (predictions.empty()) {  // Edge case
-    std::cout << "No predictions, so can't update state." << std::endl;
-    return state;
-  }
-  // Update every individual model's distribution
-  for (auto p : predictions) {
-    // Compute loss and find which model to update
-    auto loss = std::abs(feedback.y_ - p.y_hat_);
-    auto model_id = p.models_used_.front();
-
-    // Update arm weight and weight_sum
-    auto s_i = state.model_map_[model_id]["weight"];
-    if (s_i != 0) {
-      double update = exp(-eta * loss / (s_i / state.weight_sum_));
-      state.model_map_[model_id]["weight"] *= update;
-      state.set_weight_sum(state.weight_sum_ - s_i +
-                           state.model_map_[model_id]["weight"]);
-    }
-  }
-  return state;
-}
-
-std::string Exp4Policy::serialize_state(BanditPolicyState state) {
-  return state.serialize();
-}
-
-BanditPolicyState Exp4Policy::deserialize_state(const std::string& bytes) {
-  return BanditPolicyState::deserialize(bytes);
-}
-
-std::string Exp4Policy::state_debug_string(const BanditPolicyState& state) {
-  return state.debug_string();
-}
-
-// ******************
-// * Epsilon Greedy *
-// ******************
-
-BanditPolicyState EpsilonGreedyPolicy::initialize(
-    const std::vector<VersionedModelId>& candidate_models_) {
-  BanditPolicyState state;
-  Map map(candidate_models_.size(), &versioned_model_hash);
-  for (VersionedModelId id : candidate_models_) {
-    ModelInfo info = {{"expected_loss", 0.0}, {"times_selected", 0.0}};
-    map.insert({id, info});
-  }
-  state.set_model_map(map);
-  return state;
-}
-
-BanditPolicyState EpsilonGreedyPolicy::add_models(
-    BanditPolicyState state, const std::vector<VersionedModelId>& new_models) {
-  // Calculate expected loss from old models
-  auto sum = 0.0;
-  for (auto model : state.model_map_) {
-    sum += model.second.at("expected_loss");
-  }
-  auto avg = sum / state.model_map_.size();
-  // Add new model with average reward
-  for (auto id : new_models) {
-    ModelInfo info = {{"expected_loss", avg}, {"times_selected", 0.0}};
-    state.add_model(id, info);
-  }
-  return state;
-}
-
-VersionedModelId EpsilonGreedyPolicy::select(BanditPolicyState& state) {
-  // Helper function for selecting an arm based on lowest expected loss
-  VersionedModelId selected_model;
-  if (state.model_map_.empty()) {  // Edge case
-    std::cout << "No models to select from." << std::endl;
-    return selected_model;
-  }
-  double rand_num = (double)rand() / RAND_MAX;
-  if (rand_num >= epsilon) {  // Select best model
-    auto min_loss = DBL_MAX;
-    for (auto id = state.model_map_.begin(); id != state.model_map_.end();
-         ++id) {
-      auto model_loss = id->second["expected_loss"];
-      if (model_loss < min_loss) {
-        min_loss = model_loss;
-        selected_model = id->first;
-      }
-    }
-  } else {  // Randomly select
-    int rand_draw = rand() % state.model_map_.size();
-    auto random_it = next(begin(state.model_map_), rand_draw);
-    selected_model = random_it->first;
-  }
-
-  return selected_model;
-}
-
-std::vector<PredictTask> EpsilonGreedyPolicy::select_predict_tasks(
-    BanditPolicyState& state, Query query, long query_id) {
-  auto selected_model = select(state);
-  auto task = PredictTask(query.input_, selected_model, 1.0, query_id,
-                          query.latency_micros_);
-  std::vector<PredictTask> tasks{task};
   return tasks;
 }
 
-Output EpsilonGreedyPolicy::combine_predictions(
-    BanditPolicyState /*state*/, Query /*query*/,
-    std::vector<Output> predictions) {
-  if (predictions.empty()) {
-    std::cout << "No predictions to combine" << std::endl;
-    return Output(0.0, {});
-  }
-  return predictions.front();
-}
-
-std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-EpsilonGreedyPolicy::select_feedback_tasks(BanditPolicyState& state,
-                                           FeedbackQuery feedback,
-                                           long query_id) {
-  // Predict Task
-  auto selected_model = select(state);
-  auto predict_task =
-      PredictTask(feedback.feedback_.input_, selected_model, -1, query_id, -1);
-  std::vector<PredictTask> predict_tasks{predict_task};
-  // Feedback Task
-  std::vector<FeedbackTask> feedback_tasks;
-
-  return make_pair(predict_tasks, feedback_tasks);
-}
-
-BanditPolicyState EpsilonGreedyPolicy::process_feedback(
-    BanditPolicyState state, Feedback feedback,
-    std::vector<Output> predictions) {
-  // Edge case
-  if (predictions.empty()) {
-    return state;
-  }
-  auto model_id = predictions.front().models_used_.front();
-  auto new_loss = std::abs(feedback.y_ - predictions.front().y_hat_);
-  // Update expected loss
-  int times = state.model_map_[model_id]["times_selected"];
-  state.model_map_[model_id]["expected_loss"] =
-      (state.model_map_[model_id]["expected_loss"] * times + new_loss) /
-      (times + 1);
-  // Update times selected
-  state.model_map_[model_id]["times_selected"] = times + 1;
-
-  return state;
-}
-
-std::string EpsilonGreedyPolicy::serialize_state(BanditPolicyState state) {
-  return state.serialize();
-}
-
-BanditPolicyState EpsilonGreedyPolicy::deserialize_state(
-    const std::string& bytes) {
-  return BanditPolicyState::deserialize(bytes);
-}
-
-std::string EpsilonGreedyPolicy::state_debug_string(
-    const BanditPolicyState& state) {
-  return state.debug_string();
-}
-
-// ********
-// * UCB1 *
-// ********
-
-BanditPolicyState UCBPolicy::initialize(
-    const std::vector<VersionedModelId>& candidate_models_) {
-  BanditPolicyState state;
-  Map map(candidate_models_.size(), &versioned_model_hash);
-  for (VersionedModelId id : candidate_models_) {
-    ModelInfo info = {{"expected_loss", 0.0}, {"times_selected", 0.0}};
-    map.insert({id, info});
-  }
-  state.set_model_map(map);
-  return state;
-}
-
-BanditPolicyState UCBPolicy::add_models(
-    BanditPolicyState state, const std::vector<VersionedModelId>& new_models) {
-  // Calculate expected loss from old models
-  auto sum = 0.0;
-  for (auto model : state.model_map_) {
-    sum += model.second.at("expected_loss");
-  }
-  auto avg = sum / state.model_map_.size();
-  // Add new model with average reward
-  for (auto id : new_models) {
-    ModelInfo info = {{"expected_loss", avg}, {"times_selected", 0.0}};
-    state.add_model(id, info);
-  }
-  return state;
-}
-
-VersionedModelId UCBPolicy::select(BanditPolicyState& state) {
-  // Helper function for selecting an arm based on lowest upper confidence bound
-  VersionedModelId selected_model;
-  if (state.model_map_.empty()) {  // Edge case
-    std::cout << "No models to select from." << std::endl;
+Output DefaultOutputSelectionPolicy::combine_predictions(
+    const SelectionState& state, Query query,
+    std::vector<Output> predictions) const {
+  if (predictions.size() == 1) {
+    return predictions.front();
+  } else if (predictions.empty()) {
+    return dynamic_cast<const DefaultOutputSelectionState&>(state)
+        .default_output_;
   } else {
-    auto min_upper_bound = DBL_MAX;
-    for (auto id = state.model_map_.begin(); id != state.model_map_.end();
-         ++id) {
-      auto model_loss = id->second["expected_loss"];
-      auto bound =
-          sqrt(2 * log(state.model_map_.size()) / id->second["times_selected"]);
-      if (model_loss + bound < min_upper_bound) {
-        min_upper_bound = model_loss + bound;
-        selected_model = id->first;
-      }
-    }
+    log_error_formatted(LOGGING_TAG_SELECTION_POLICY,
+                        "DefaultOutputSelectionPolicy only expecting 1 "
+                        "output but found {}. Returning the first one.",
+                        predictions.size());
+    return predictions.front();
   }
-
-  return selected_model;
-}
-
-std::vector<PredictTask> UCBPolicy::select_predict_tasks(
-    BanditPolicyState& state, Query query, long query_id) {
-  auto selected_model = select(state);
-  auto task = PredictTask(query.input_, selected_model, 1.0, query_id,
-                          query.latency_micros_);
-  std::vector<PredictTask> tasks{task};
-  return tasks;
-}
-
-Output UCBPolicy::combine_predictions(BanditPolicyState /*state*/,
-                                      Query /*query*/,
-                                      std::vector<Output> predictions) {
-  if (predictions.empty()) {
-    std::cout << "No predictions to combine" << std::endl;
-    return Output(0.0, {});
-  }
-  return predictions.front();
 }
 
 std::pair<std::vector<PredictTask>, std::vector<FeedbackTask>>
-UCBPolicy::select_feedback_tasks(BanditPolicyState& state,
-                                 FeedbackQuery feedback, long query_id) {
-  // Predict Task
-  auto selected_model = select(state);
-  auto predict_task =
-      PredictTask(feedback.feedback_.input_, selected_model, -1, query_id, -1);
-  std::vector<PredictTask> predict_tasks{predict_task};
-  // Feedback Task
-  std::vector<FeedbackTask> feedback_tasks;
-
-  return make_pair(predict_tasks, feedback_tasks);
+DefaultOutputSelectionPolicy::select_feedback_tasks(
+    const SelectionState& /*state*/, FeedbackQuery /*query*/,
+    long /*query_id*/) const {
+  return std::make_pair<std::vector<PredictTask>, std::vector<FeedbackTask>>(
+      {}, {});
 }
 
-BanditPolicyState UCBPolicy::process_feedback(BanditPolicyState state,
-                                              Feedback feedback,
-                                              std::vector<Output> predictions) {
-  // Edge case
-  if (predictions.empty()) {
-    return state;
-  }
-  auto model_id = predictions.front().models_used_.front();
-  auto new_loss = std::abs(feedback.y_ - predictions.front().y_hat_);
-  // Update expected loss
-  int times = state.model_map_[model_id]["times_selected"];
-  state.model_map_[model_id]["expected_loss"] =
-      (state.model_map_[model_id]["expected_loss"] * times + new_loss) /
-      (times + 1);
-  // Update times selected
-  state.model_map_[model_id]["times_selected"] = times + 1;
-
+SelectionState DefaultOutputSelectionPolicy::process_feedback(
+    SelectionState state, Feedback /*feedback*/,
+    std::vector<Output> /*predictions*/) const {
   return state;
 }
 
-std::string UCBPolicy::serialize_state(BanditPolicyState state) {
-  return state.serialize();
+SelectionState DefaultOutputSelectionPolicy::deserialize(
+    std::string serialized_state) const {
+  return DefaultOutputSelectionState(serialized_state);
 }
 
-BanditPolicyState UCBPolicy::deserialize_state(const std::string& bytes) {
-  return BanditPolicyState::deserialize(bytes);
-}
-
-std::string UCBPolicy::state_debug_string(const BanditPolicyState& state) {
-  return state.debug_string();
+std::string DefaultOutputSelectionPolicy::serialize(
+    SelectionState state) const {
+  return dynamic_cast<const DefaultOutputSelectionState&>(state).serialize();
 }
 
 }  // namespace clipper

--- a/src/libclipper/src/selection_policies.cpp
+++ b/src/libclipper/src/selection_policies.cpp
@@ -42,7 +42,7 @@ Output DefaultOutputSelectionState::deserialize(std::string serialized_state) {
   return Output(json::get_double(d, "y_hat"), {});
 }
 
-DefaultOutputSelectionPolicy::std::string get_name() const {
+std::string DefaultOutputSelectionPolicy::get_name() {
   return "DefaultOutputSelectionPolicy";
 }
 

--- a/src/libclipper/src/selection_policies.cpp
+++ b/src/libclipper/src/selection_policies.cpp
@@ -73,20 +73,23 @@ std::vector<PredictTask> DefaultOutputSelectionPolicy::select_predict_tasks(
   return tasks;
 }
 
-Output DefaultOutputSelectionPolicy::combine_predictions(
-    const std::shared_ptr<SelectionState>& state, Query /*query*/,
+const std::pair<Output, bool>
+DefaultOutputSelectionPolicy::combine_predictions(
+    const std::shared_ptr<SelectionState>& state,
+    Query /*query*/,
     std::vector<Output> predictions) const {
   if (predictions.size() == 1) {
-    return predictions.front();
+    return std::make_pair(std::move(predictions.front()), false);
   } else if (predictions.empty()) {
-    return std::dynamic_pointer_cast<DefaultOutputSelectionState>(state)
-        ->default_output_;
+    Output default_output =
+        std::dynamic_pointer_cast<DefaultOutputSelectionState>(state)->default_output_;
+    return std::make_pair(std::move(default_output), true);
   } else {
     log_error_formatted(LOGGING_TAG_SELECTION_POLICY,
                         "DefaultOutputSelectionPolicy only expecting 1 "
                         "output but found {}. Returning the first one.",
                         predictions.size());
-    return predictions.front();
+    return std::make_pair(std::move(predictions.front()), false);
   }
 }
 

--- a/src/libclipper/src/selection_policies.cpp
+++ b/src/libclipper/src/selection_policies.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include <rapidjson/document.h>
+// #include <rapidjson/document.h>
 
 #include <clipper/datatypes.hpp>
 #include <clipper/json_util.hpp>

--- a/src/libclipper/src/selection_policies.cpp
+++ b/src/libclipper/src/selection_policies.cpp
@@ -1,20 +1,10 @@
-// #include <float.h>
-// #include <math.h>
-// #include <time.h>
 #include <functional>
 #include <iostream>
-// #include <random>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
-
-// #include <boost/archive/binary_iarchive.hpp>
-// #include <boost/archive/binary_oarchive.hpp>
-// #include <boost/serialization/string.hpp>
-// #include <boost/serialization/unordered_map.hpp>
-// #include <boost/serialization/utility.hpp>
 
 #include <rapidjson/document.h>
 
@@ -25,8 +15,6 @@
 #include <clipper/util.hpp>
 
 namespace clipper {
-
-// DefaultOutputSelectionState
 
 DefaultOutputSelectionState::DefaultOutputSelectionState(Output default_output)
     : default_output_(default_output) {}
@@ -56,8 +44,6 @@ Output DefaultOutputSelectionState::deserialize(std::string serialized_state) {
   return Output(json::get_double(d, "y_hat"), {});
 }
 
-///////////////////// DefaultOutputSelectionPolicy ////////////////////
-
 std::shared_ptr<SelectionState> DefaultOutputSelectionPolicy::init_state(
     Output default_output) const {
   return std::make_shared<DefaultOutputSelectionState>(default_output);
@@ -74,14 +60,14 @@ std::vector<PredictTask> DefaultOutputSelectionPolicy::select_predict_tasks(
                         query.label_);
   } else if (num_candidate_models == 1) {
     tasks.emplace_back(query.input_, query.candidate_models_.front(), 1.0,
-                       query_id, query.deadline_);
+                       query_id, query.latency_budget_micros_);
   } else {
     log_error_formatted(LOGGING_TAG_SELECTION_POLICY,
                         "{} candidate models provided for query with label "
                         "{}. Picking the first one.",
                         num_candidate_models, query.label_);
     tasks.emplace_back(query.input_, query.candidate_models_.front(), 1.0,
-                       query_id, query.deadline_);
+                       query_id, query.latency_budget_micros_);
   }
   return tasks;
 }

--- a/src/libclipper/test/input_test.cpp
+++ b/src/libclipper/test/input_test.cpp
@@ -9,7 +9,7 @@ using std::vector;
 
 namespace {
 
-const unsigned long SERIALIZED_REQUEST_SIZE = 3;
+const unsigned long SERIALIZED_REQUEST_SIZE = 5;
 const int NUM_PRIMITIVE_INPUTS = 500;
 const int NUM_STRING_INPUTS = 300;
 const uint8_t PRIMITIVE_INPUT_SIZE_ELEMS = 200;
@@ -66,8 +66,18 @@ TEST(InputSerializationTests, ByteSerialization) {
   std::vector<clipper::ByteBuffer> serialized_request = request.serialize();
   ASSERT_EQ(serialized_request.size(), SERIALIZED_REQUEST_SIZE);
   clipper::ByteBuffer request_header = serialized_request[0];
-  clipper::ByteBuffer input_header = serialized_request[1];
-  clipper::ByteBuffer raw_content = serialized_request[2];
+  clipper::ByteBuffer input_header_size = serialized_request[1];
+  clipper::ByteBuffer input_header = serialized_request[2];
+  clipper::ByteBuffer input_content_size = serialized_request[3];
+  clipper::ByteBuffer input_content = serialized_request[4];
+
+  long* raw_input_header_size =
+      reinterpret_cast<long*>(input_header_size.data());
+  ASSERT_EQ(raw_input_header_size[0], input_header.size());
+  long* raw_input_content_size =
+      reinterpret_cast<long*>(input_content_size.data());
+  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
   ASSERT_EQ(*raw_request_type,
@@ -81,7 +91,7 @@ TEST(InputSerializationTests, ByteSerialization) {
   ASSERT_EQ(num_inputs, static_cast<uint32_t>(data_vectors.size()));
   typed_input_header++;
 
-  uint8_t* content_ptr = raw_content.data();
+  uint8_t* content_ptr = input_content.data();
   uint32_t prev_index = 0;
   for (int i = 0; i < (int)num_inputs - 1; i++) {
     uint32_t split_index = typed_input_header[i];
@@ -98,7 +108,7 @@ TEST(InputSerializationTests, ByteSerialization) {
   // the total content length.
   std::vector<uint8_t> tail_vec(
       content_ptr + prev_index,
-      content_ptr + (raw_content.size() / sizeof(uint8_t)));
+      content_ptr + (input_content.size() / sizeof(uint8_t)));
   ASSERT_EQ(tail_vec, data_vectors[data_vectors.size() - 1]);
 }
 
@@ -113,9 +123,20 @@ TEST(InputSerializationTests, IntSerialization) {
   }
   std::vector<clipper::ByteBuffer> serialized_request = request.serialize();
   ASSERT_EQ(serialized_request.size(), SERIALIZED_REQUEST_SIZE);
+
   clipper::ByteBuffer request_header = serialized_request[0];
-  clipper::ByteBuffer input_header = serialized_request[1];
-  clipper::ByteBuffer raw_content = serialized_request[2];
+  clipper::ByteBuffer input_header_size = serialized_request[1];
+  clipper::ByteBuffer input_header = serialized_request[2];
+  clipper::ByteBuffer input_content_size = serialized_request[3];
+  clipper::ByteBuffer input_content = serialized_request[4];
+
+  long* raw_input_header_size =
+      reinterpret_cast<long*>(input_header_size.data());
+  ASSERT_EQ(raw_input_header_size[0], input_header.size());
+  long* raw_input_content_size =
+      reinterpret_cast<long*>(input_content_size.data());
+  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
   ASSERT_EQ(*raw_request_type,
@@ -129,7 +150,7 @@ TEST(InputSerializationTests, IntSerialization) {
   ASSERT_EQ(num_inputs, static_cast<uint32_t>(data_vectors.size()));
   typed_input_header++;
 
-  int* content_ptr = reinterpret_cast<int*>(raw_content.data());
+  int* content_ptr = reinterpret_cast<int*>(input_content.data());
   uint32_t prev_index = 0;
   for (int i = 0; i < (int)num_inputs - 1; i++) {
     uint32_t split_index = typed_input_header[i];
@@ -144,7 +165,7 @@ TEST(InputSerializationTests, IntSerialization) {
   // This vector is composed of the elements from the last split index through
   // the total content length.
   std::vector<int> tail_vec(content_ptr + prev_index,
-                            content_ptr + (raw_content.size() / sizeof(int)));
+                            content_ptr + (input_content.size() / sizeof(int)));
   ASSERT_EQ(tail_vec, data_vectors[data_vectors.size() - 1]);
 }
 
@@ -159,9 +180,20 @@ TEST(InputSerializationTests, FloatSerialization) {
   }
   std::vector<clipper::ByteBuffer> serialized_request = request.serialize();
   ASSERT_EQ(serialized_request.size(), SERIALIZED_REQUEST_SIZE);
+
   clipper::ByteBuffer request_header = serialized_request[0];
-  clipper::ByteBuffer input_header = serialized_request[1];
-  clipper::ByteBuffer raw_content = serialized_request[2];
+  clipper::ByteBuffer input_header_size = serialized_request[1];
+  clipper::ByteBuffer input_header = serialized_request[2];
+  clipper::ByteBuffer input_content_size = serialized_request[3];
+  clipper::ByteBuffer input_content = serialized_request[4];
+
+  long* raw_input_header_size =
+      reinterpret_cast<long*>(input_header_size.data());
+  ASSERT_EQ(raw_input_header_size[0], input_header.size());
+  long* raw_input_content_size =
+      reinterpret_cast<long*>(input_content_size.data());
+  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
   ASSERT_EQ(*raw_request_type,
@@ -175,7 +207,7 @@ TEST(InputSerializationTests, FloatSerialization) {
   ASSERT_EQ(num_inputs, static_cast<uint32_t>(data_vectors.size()));
   typed_input_header++;
 
-  float* content_ptr = reinterpret_cast<float*>(raw_content.data());
+  float* content_ptr = reinterpret_cast<float*>(input_content.data());
   uint32_t prev_index = 0;
   for (int i = 0; i < (int)num_inputs - 1; i++) {
     uint32_t split_index = typed_input_header[i];
@@ -191,7 +223,7 @@ TEST(InputSerializationTests, FloatSerialization) {
   // the total content length.
   std::vector<float> tail_vec(
       content_ptr + prev_index,
-      content_ptr + (raw_content.size() / sizeof(float)));
+      content_ptr + (input_content.size() / sizeof(float)));
   ASSERT_EQ(tail_vec, data_vectors[data_vectors.size() - 1]);
 }
 
@@ -206,9 +238,20 @@ TEST(InputSerializationTests, DoubleSerialization) {
   }
   std::vector<clipper::ByteBuffer> serialized_request = request.serialize();
   ASSERT_EQ(serialized_request.size(), SERIALIZED_REQUEST_SIZE);
+
   clipper::ByteBuffer request_header = serialized_request[0];
-  clipper::ByteBuffer input_header = serialized_request[1];
-  clipper::ByteBuffer raw_content = serialized_request[2];
+  clipper::ByteBuffer input_header_size = serialized_request[1];
+  clipper::ByteBuffer input_header = serialized_request[2];
+  clipper::ByteBuffer input_content_size = serialized_request[3];
+  clipper::ByteBuffer input_content = serialized_request[4];
+
+  long* raw_input_header_size =
+      reinterpret_cast<long*>(input_header_size.data());
+  ASSERT_EQ(raw_input_header_size[0], input_header.size());
+  long* raw_input_content_size =
+      reinterpret_cast<long*>(input_content_size.data());
+  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
   ASSERT_EQ(*raw_request_type,
@@ -222,7 +265,7 @@ TEST(InputSerializationTests, DoubleSerialization) {
   ASSERT_EQ(num_inputs, static_cast<uint32_t>(data_vectors.size()));
   typed_input_header++;
 
-  double* content_ptr = reinterpret_cast<double*>(raw_content.data());
+  double* content_ptr = reinterpret_cast<double*>(input_content.data());
   uint32_t prev_index = 0;
   for (int i = 0; i < (int)num_inputs - 1; i++) {
     uint32_t split_index = typed_input_header[i];
@@ -239,7 +282,7 @@ TEST(InputSerializationTests, DoubleSerialization) {
   // the total content length.
   std::vector<double> tail_vec(
       content_ptr + prev_index,
-      content_ptr + (raw_content.size() / sizeof(double)));
+      content_ptr + (input_content.size() / sizeof(double)));
   ASSERT_EQ(tail_vec, data_vectors[data_vectors.size() - 1]);
 }
 
@@ -255,8 +298,18 @@ TEST(InputSerializationTests, StringSerialization) {
   std::vector<clipper::ByteBuffer> serialized_request = request.serialize();
   ASSERT_EQ(serialized_request.size(), SERIALIZED_REQUEST_SIZE);
   clipper::ByteBuffer request_header = serialized_request[0];
-  clipper::ByteBuffer input_header = serialized_request[1];
-  clipper::ByteBuffer raw_content = serialized_request[2];
+  clipper::ByteBuffer input_header_size = serialized_request[1];
+  clipper::ByteBuffer input_header = serialized_request[2];
+  clipper::ByteBuffer input_content_size = serialized_request[3];
+  clipper::ByteBuffer input_content = serialized_request[4];
+
+  long* raw_input_header_size =
+      reinterpret_cast<long*>(input_header_size.data());
+  ASSERT_EQ(raw_input_header_size[0], input_header.size());
+  long* raw_input_content_size =
+      reinterpret_cast<long*>(input_content_size.data());
+  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
   ASSERT_EQ(*raw_request_type,
@@ -270,7 +323,7 @@ TEST(InputSerializationTests, StringSerialization) {
   ASSERT_EQ(num_inputs, static_cast<uint32_t>(string_vector.size()));
   typed_input_header++;
 
-  char* content_ptr = reinterpret_cast<char*>(raw_content.data());
+  char* content_ptr = reinterpret_cast<char*>(input_content.data());
   for (int i = 0; i < (int)num_inputs; i++) {
     std::string str(content_ptr);
     ASSERT_EQ(str, string_vector[i]);

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -146,7 +146,7 @@ TEST_F(RedisTest, AddApplication) {
       std::make_pair("music_random_features", 1),
       std::make_pair("simple_svm", 2), std::make_pair("music_cnn", 4)};
   InputType input_type = InputType::Doubles;
-  std::string policy = "exp3_policy";
+  std::string policy = DefaultOutputSelectionPolicy::get_name();
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   ASSERT_TRUE(add_application(*redis_, name, models, input_type, policy,

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -147,17 +147,19 @@ TEST_F(RedisTest, AddApplication) {
       std::make_pair("simple_svm", 2), std::make_pair("music_cnn", 4)};
   InputType input_type = InputType::Doubles;
   std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   ASSERT_TRUE(add_application(*redis_, name, models, input_type, policy,
-                              latency_slo_micros));
+                              default_output, latency_slo_micros));
   auto result = get_application(*redis_, name);
   // The application table has 5 fields, so we expect to get back a map with 5
   // entries in it (see add_application() in redis.cpp for details on what the
   // fields are).
-  EXPECT_EQ(result.size(), static_cast<size_t>(4));
+  EXPECT_EQ(result.size(), static_cast<size_t>(5));
   EXPECT_EQ(str_to_models(result["candidate_models"]), models);
   EXPECT_EQ(parse_input_type(result["input_type"]), input_type);
   EXPECT_EQ(result["policy"], policy);
+  EXPECT_EQ(result["default_output"], default_output);
   EXPECT_EQ(std::stoi(result["latency_slo_micros"]), latency_slo_micros);
 }
 
@@ -168,11 +170,12 @@ TEST_F(RedisTest, DeleteApplication) {
       std::make_pair("music_cnn", 4)};
   InputType input_type = InputType::Doubles;
   std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   ASSERT_TRUE(add_application(*redis_, name, models, input_type, policy,
-                              latency_slo_micros));
+                              default_output, latency_slo_micros));
   auto get_result = get_application(*redis_, name);
-  EXPECT_EQ(get_result.size(), static_cast<size_t>(4));
+  EXPECT_EQ(get_result.size(), static_cast<size_t>(5));
   ASSERT_TRUE(delete_application(*redis_, name));
   auto delete_result = get_application(*redis_, name);
   EXPECT_EQ(delete_result.size(), static_cast<size_t>(0));
@@ -313,6 +316,7 @@ TEST_F(RedisTest, SubscriptionDetectApplicationAdd) {
       std::make_pair("music_cnn", 4)};
   InputType input_type = InputType::Doubles;
   std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
   int latency_slo_micros = 10000;
 
   std::condition_variable_any notification_recv;
@@ -331,7 +335,7 @@ TEST_F(RedisTest, SubscriptionDetectApplicationAdd) {
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   ASSERT_TRUE(add_application(*redis_, name, models, input_type, policy,
-                              latency_slo_micros));
+                              default_output, latency_slo_micros));
 
   std::unique_lock<std::mutex> l(notification_mutex);
   bool result = notification_recv.wait_for(l, std::chrono::milliseconds(1000),
@@ -346,9 +350,10 @@ TEST_F(RedisTest, SubscriptionDetectApplicationDelete) {
       std::make_pair("music_cnn", 4)};
   InputType input_type = InputType::Doubles;
   std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   ASSERT_TRUE(add_application(*redis_, name, models, input_type, policy,
-                              latency_slo_micros));
+                              default_output, latency_slo_micros));
   std::condition_variable_any notification_recv;
   std::mutex notification_mutex;
   std::atomic<bool> recv{false};

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -9,6 +9,7 @@
 #include <clipper/datatypes.hpp>
 #include <clipper/logging.hpp>
 #include <clipper/redis.hpp>
+#include <clipper/selection_policies.hpp>
 #include <redox.hpp>
 
 using namespace clipper;

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -370,4 +370,25 @@ TEST_F(RedisTest, SubscriptionDetectApplicationDelete) {
   ASSERT_TRUE(result);
 }
 
+TEST_F(RedisTest, LabelsToStr) {
+  std::vector<std::string> labels{"ads", "images", "experimental", "other",
+                                  "labels"};
+  ASSERT_EQ(labels_to_str(labels), "ads,images,experimental,other,labels");
+
+  labels.clear();
+  ASSERT_EQ(labels_to_str(labels), "");
+}
+
+TEST_F(RedisTest, ModelsToStr) {
+  std::vector<VersionedModelId> models{
+      std::make_pair("music_random_features", 1),
+      std::make_pair("simple_svm", 2), std::make_pair("music_cnn", 4)};
+
+  ASSERT_EQ(models_to_str(models),
+            "music_random_features:1,simple_svm:2,music_cnn:4");
+
+  models.clear();
+  ASSERT_EQ(models_to_str(models), "");
+}
+
 }  // namespace

--- a/src/libclipper/test/selection_policies_test.cpp
+++ b/src/libclipper/test/selection_policies_test.cpp
@@ -23,57 +23,92 @@ class DefaultOutputSelectionPolicyTest : public ::testing::Test {
   std::shared_ptr<DefaultOutputSelectionState> state_;
 };
 
-TEST_F(DefaultOutputSelectionPolicyTest, InitState) {}
-
-TEST_F(DefaultOutputSelectionPolicyTest, TestSelectPredictTasks) {
-  Query zero_candidate_models_query{
-      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
-      1000,    "DefaultOutputSelectionPolicy", {}};
+TEST_F(DefaultOutputSelectionPolicyTest,
+       TestSelectPredictTasksZeroCandidateModels) {
+  Query zero_candidate_models_query{"label",
+                                    clipper::DEFAULT_USER_ID,
+                                    std::shared_ptr<DoubleVector>(),
+                                    1000,
+                                    DefaultOutputSelectionPolicy::get_name(),
+                                    {}};
   auto zero_models_tasks =
       policy_.select_predict_tasks(nullptr, zero_candidate_models_query, 0);
   EXPECT_EQ(zero_models_tasks.size(), (size_t)0);
+}
 
+TEST_F(DefaultOutputSelectionPolicyTest,
+       TestSelectPredictTasksTwoCandidateModels) {
   std::vector<VersionedModelId> two_models{
       std::make_pair("music_random_features", 1),
       std::make_pair("simple_svm", 2)};
-  Query two_candidate_models_query{
-      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
-      1000,    "DefaultOutputSelectionPolicy", two_models};
+  Query two_candidate_models_query{"label",
+                                   clipper::DEFAULT_USER_ID,
+                                   std::shared_ptr<DoubleVector>(),
+                                   1000,
+                                   DefaultOutputSelectionPolicy::get_name(),
+                                   two_models};
   auto two_models_tasks =
       policy_.select_predict_tasks(nullptr, two_candidate_models_query, 0);
   EXPECT_EQ(two_models_tasks.size(), (size_t)1);
   EXPECT_EQ(two_models_tasks.front().model_, two_models.front());
+}
 
+TEST_F(DefaultOutputSelectionPolicyTest,
+       TestSelectPredictTasksOneCandidateModel) {
   std::vector<VersionedModelId> one_model{
       std::make_pair("music_random_features", 1)};
-  Query one_candidate_model_query{
-      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
-      1000,    "DefaultOutputSelectionPolicy", one_model};
+  Query one_candidate_model_query{"label",
+                                  clipper::DEFAULT_USER_ID,
+                                  std::shared_ptr<DoubleVector>(),
+                                  1000,
+                                  DefaultOutputSelectionPolicy::get_name(),
+                                  one_model};
   auto one_model_tasks =
       policy_.select_predict_tasks(nullptr, one_candidate_model_query, 0);
   EXPECT_EQ(one_model_tasks.size(), (size_t)1);
   EXPECT_EQ(one_model_tasks.front().model_, one_model.front());
 }
 
-TEST_F(DefaultOutputSelectionPolicyTest, TestCombinePredictions) {
+TEST_F(DefaultOutputSelectionPolicyTest,
+       TestCombinePredictionsZeroPredictions) {
   VersionedModelId m1 = std::make_pair("music_random_features", 1);
-  VersionedModelId m2 = std::make_pair("simple_svm", 2);
-  Query one_candidate_model_query{
-      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
-      1000,    "DefaultOutputSelectionPolicy", {m1}};
+  Query one_candidate_model_query{"label",
+                                  clipper::DEFAULT_USER_ID,
+                                  std::shared_ptr<DoubleVector>(),
+                                  1000,
+                                  DefaultOutputSelectionPolicy::get_name(),
+                                  {m1}};
   auto zero_preds_output =
       policy_.combine_predictions(state_, one_candidate_model_query, {});
   ASSERT_EQ(zero_preds_output, state_->default_output_);
+}
+
+TEST_F(DefaultOutputSelectionPolicyTest, TestCombinePredictionsOnePrediction) {
+  VersionedModelId m1 = std::make_pair("music_random_features", 1);
+  Query one_candidate_model_query{"label",
+                                  clipper::DEFAULT_USER_ID,
+                                  std::shared_ptr<DoubleVector>(),
+                                  1000,
+                                  DefaultOutputSelectionPolicy::get_name(),
+                                  {m1}};
 
   Output first_output = Output{1.1, {m1}};
   auto one_pred_output = policy_.combine_predictions(
       state_, one_candidate_model_query, {first_output});
   ASSERT_EQ(one_pred_output, first_output);
   ASSERT_NE(one_pred_output, state_->default_output_);
+}
 
-  Query two_candidate_models_query{
-      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
-      1000,    "DefaultOutputSelectionPolicy", {m1, m2}};
+TEST_F(DefaultOutputSelectionPolicyTest, TestCombinePredictionsTwoPredictions) {
+  VersionedModelId m1 = std::make_pair("music_random_features", 1);
+  VersionedModelId m2 = std::make_pair("simple_svm", 2);
+  Query two_candidate_models_query{"label",
+                                   clipper::DEFAULT_USER_ID,
+                                   std::shared_ptr<DoubleVector>(),
+                                   1000,
+                                   DefaultOutputSelectionPolicy::get_name(),
+                                   {m1, m2}};
+  Output first_output = Output{1.1, {m1}};
   Output second_output = Output{2.2, {m2}};
   auto two_preds_output = policy_.combine_predictions(
       state_, two_candidate_models_query, {first_output, second_output});

--- a/src/libclipper/test/selection_policies_test.cpp
+++ b/src/libclipper/test/selection_policies_test.cpp
@@ -79,7 +79,7 @@ TEST_F(DefaultOutputSelectionPolicyTest,
                                   DefaultOutputSelectionPolicy::get_name(),
                                   {m1}};
   auto zero_preds_output =
-      policy_.combine_predictions(state_, one_candidate_model_query, {});
+      policy_.combine_predictions(state_, one_candidate_model_query, {}).first;
   ASSERT_EQ(zero_preds_output, state_->default_output_);
 }
 
@@ -94,7 +94,7 @@ TEST_F(DefaultOutputSelectionPolicyTest, TestCombinePredictionsOnePrediction) {
 
   Output first_output = Output{1.1, {m1}};
   auto one_pred_output = policy_.combine_predictions(
-      state_, one_candidate_model_query, {first_output});
+      state_, one_candidate_model_query, {first_output}).first;
   ASSERT_EQ(one_pred_output, first_output);
   ASSERT_NE(one_pred_output, state_->default_output_);
 }
@@ -111,7 +111,7 @@ TEST_F(DefaultOutputSelectionPolicyTest, TestCombinePredictionsTwoPredictions) {
   Output first_output = Output{1.1, {m1}};
   Output second_output = Output{2.2, {m2}};
   auto two_preds_output = policy_.combine_predictions(
-      state_, two_candidate_models_query, {first_output, second_output});
+      state_, two_candidate_models_query, {first_output, second_output}).first;
   ASSERT_EQ(two_preds_output, first_output);
   ASSERT_NE(two_preds_output, state_->default_output_);
 }

--- a/src/libclipper/test/selection_policies_test.cpp
+++ b/src/libclipper/test/selection_policies_test.cpp
@@ -9,298 +9,84 @@
 #include <clipper/datatypes.hpp>
 #include <clipper/selection_policies.hpp>
 
-/* UNIT TESTS LOGISTICS
-    1. Used 3 binary classifiers (good=0, so-so=1, bad=2)
-    2. Set feedback as 1
-    3. Good classifier has 75% chance returning 1, so-so has 50%, bad has 25%
-*/
 using namespace clipper;
+const std::string LOGGING_TAG_SELECTION_POLICY_TEST = "POLICY TEST";
 
 namespace {
 
-// Helper Functions
-class Utility {
+class DefaultOutputSelectionPolicyTest : public ::testing::Test {
  public:
-  // Input
-  static std::shared_ptr<Input> create_input() {
-    boost::random::mt19937 gen(std::time(0));
-    int input_len = 100;
-    vector<double> input;
-    boost::random::uniform_real_distribution<> dist(0.0, 1.0);
-    for (int i = 0; i < input_len; ++i) {
-      input.push_back(dist(gen));
-    }
-    return std::make_shared<DoubleVector>(input);
+  DefaultOutputSelectionPolicyTest()
+      : state_(std::make_shared<DefaultOutputSelectionState>(Output{4.3, {}})) {
   }
-
-  // Feedback
-  static Feedback create_feedback(double y) {
-    auto input = create_input();
-    return Feedback(input, y);
-  }
-
-  // Predictions
-  static std::vector<Output> create_predictions(VersionedModelId model,
-                                                double y_hat) {
-    std::vector<Output> predictions = {Output(y_hat, {model})};
-    return predictions;
-  }
-
-  // Query
-  static Query create_query(std::vector<VersionedModelId> models) {
-    auto input = create_input();
-    Query query("label", 1000, input, 1000, "EXP3", models);
-    return query;
-  }
+  DefaultOutputSelectionPolicy policy_;
+  std::shared_ptr<DefaultOutputSelectionState> state_;
 };
 
-// ********
-// * EXP3 *
-// ********
-class PolicyTests : public ::testing::Test {
- public:
-  virtual void SetUp() {
-    models.emplace_back(model_0);  // good
-    models.emplace_back(model_1);  // so-so
-    models.emplace_back(model_2);  // bad
-  }
-  std::vector<VersionedModelId> models;
-  VersionedModelId model_0 = std::make_pair("classifier0", 0);
-  VersionedModelId model_1 = std::make_pair("classifier1", 1);
-  VersionedModelId model_2 = std::make_pair("classifier2", 2);
-  int update_times_ = 200;
-  int select_times_ = 100;
-};
+TEST_F(DefaultOutputSelectionPolicyTest, InitState) {}
 
-TEST_F(PolicyTests, Exp3Test) {
-  /* Update Test */
-  BanditPolicyState state = Exp3Policy::initialize(models);
-  auto feedback = Utility::create_feedback(1);
-  std::vector<Output> predictions;
-  int y_hat;
-  int rand_index;
-  int rand_draw;
-  srand(time(NULL));
+TEST_F(DefaultOutputSelectionPolicyTest, TestSelectPredictTasks) {
+  Query zero_candidate_models_query{
+      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
+      1000,    "DefaultOutputSelectionPolicy", {}};
+  auto zero_models_tasks =
+      policy_.select_predict_tasks(nullptr, zero_candidate_models_query, 0);
+  EXPECT_EQ(zero_models_tasks.size(), (size_t)0);
 
-  for (int i = 0; i < update_times_; ++i) {
-    y_hat = 0;
-    rand_index = rand() % models.size();  // Randomly pick model
-    rand_draw = rand() % 100;  // Randomly pick number to determine whether this
-                               // model return 0 or 1
-    if (rand_index == 0) {     // good model
-      if (rand_draw < 75) {
-        y_hat = 1;
-      }
-    } else if (rand_index == 1) {  // so-so model
-      if (rand_draw < 50) {
-        y_hat = 1;
-      }
-    } else {
-      if (rand_draw < 25) {  // bad model
-        y_hat = 1;
-      }
-    }
-    predictions = Utility::create_predictions(models[rand_index], y_hat);
-    state = Exp3Policy::process_feedback(state, feedback, predictions);
-  }
-  // Test if model_0 weight > model_1 weight > model_2 weight
-  ASSERT_GT(state.model_map_[model_0]["weight"],
-            state.model_map_[model_1]["weight"]);
-  ASSERT_GT(state.model_map_[model_1]["weight"],
-            state.model_map_[model_2]["weight"]);
+  std::vector<VersionedModelId> two_models{
+      std::make_pair("music_random_features", 1),
+      std::make_pair("simple_svm", 2)};
+  Query two_candidate_models_query{
+      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
+      1000,    "DefaultOutputSelectionPolicy", two_models};
+  auto two_models_tasks =
+      policy_.select_predict_tasks(nullptr, two_candidate_models_query, 0);
+  EXPECT_EQ(two_models_tasks.size(), (size_t)1);
+  EXPECT_EQ(two_models_tasks.front().model_, two_models.front());
 
-  /* Selection Test */
-  auto query = Utility::create_query(models);
-  int select_0 = 0;
-  int select_1 = 0;
-  int select_2 = 0;
-  for (int i = 0; i < select_times_; ++i) {
-    auto tasks = Exp3Policy::select_predict_tasks(state, query, 1000);
-    if (model_0.second == tasks.front().model_.second) {
-      select_0++;
-    } else if (model_1.second == tasks.front().model_.second) {
-      select_1++;
-    } else {
-      select_2++;
-    };
-  }
-  // Test if times selected model_0 > model_1 > model_2
-  ASSERT_GT(select_0, select_1);
-  ASSERT_GT(select_1, select_2);
-
-  /* Serialization Test */
-  auto bytes = Exp3Policy::serialize_state(state);
-  auto new_state = Exp3Policy::deserialize_state(bytes);
-  ASSERT_EQ(state.weight_sum_, new_state.weight_sum_);
+  std::vector<VersionedModelId> one_model{
+      std::make_pair("music_random_features", 1)};
+  Query one_candidate_model_query{
+      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
+      1000,    "DefaultOutputSelectionPolicy", one_model};
+  auto one_model_tasks =
+      policy_.select_predict_tasks(nullptr, one_candidate_model_query, 0);
+  EXPECT_EQ(one_model_tasks.size(), (size_t)1);
+  EXPECT_EQ(one_model_tasks.front().model_, one_model.front());
 }
 
-// ********
-// * EXP4 *
-// ********
+TEST_F(DefaultOutputSelectionPolicyTest, TestCombinePredictions) {
+  VersionedModelId m1 = std::make_pair("music_random_features", 1);
+  VersionedModelId m2 = std::make_pair("simple_svm", 2);
+  Query one_candidate_model_query{
+      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
+      1000,    "DefaultOutputSelectionPolicy", {m1}};
+  auto zero_preds_output =
+      policy_.combine_predictions(state_, one_candidate_model_query, {});
+  ASSERT_EQ(zero_preds_output, state_->default_output_);
 
-TEST_F(PolicyTests, Exp4Test) {
-  /* Update Test */
-  BanditPolicyState state = Exp4Policy::initialize(models);
-  auto feedback = Utility::create_feedback(1);
-  std::vector<Output> predictions;
-  int y_hat;
-  int rand_index;
-  int rand_draw;
-  srand(time(NULL));
+  Output first_output = Output{1.1, {m1}};
+  auto one_pred_output = policy_.combine_predictions(
+      state_, one_candidate_model_query, {first_output});
+  ASSERT_EQ(one_pred_output, first_output);
+  ASSERT_NE(one_pred_output, state_->default_output_);
 
-  for (int i = 0; i < update_times_; ++i) {
-    y_hat = 0;
-    rand_index = rand() % models.size();  // Randomly pick model
-    rand_draw = rand() % 100;  // Randomly pick number to determine whether this
-                               // model return 0 or 1
-
-    if (rand_index == 0) {  // good model
-      if (rand_draw < 75) {
-        y_hat = 1;
-      }
-    } else if (rand_index == 1) {  // so-so model
-      if (rand_draw < 50) {
-        y_hat = 1;
-      }
-    } else {
-      if (rand_draw < 25) {  // bad model
-        y_hat = 1;
-      }
-    }
-    predictions = Utility::create_predictions(models[rand_index], y_hat);
-    state = Exp4Policy::process_feedback(state, feedback, predictions);
-  }
-  // Test if model_0 weight > model_1 weight > model_2 weight
-  ASSERT_GT(state.model_map_[model_0]["weight"],
-            state.model_map_[model_1]["weight"]);
-  ASSERT_GT(state.model_map_[model_1]["weight"],
-            state.model_map_[model_2]["weight"]);
-
-  /* Serialization Test */
-  auto bytes = Exp4Policy::serialize_state(state);
-  auto new_state = Exp4Policy::deserialize_state(bytes);
-  ASSERT_EQ(state.weight_sum_, new_state.weight_sum_);
+  Query two_candidate_models_query{
+      "label", clipper::DEFAULT_USER_ID,       std::shared_ptr<DoubleVector>(),
+      1000,    "DefaultOutputSelectionPolicy", {m1, m2}};
+  Output second_output = Output{2.2, {m2}};
+  auto two_preds_output = policy_.combine_predictions(
+      state_, two_candidate_models_query, {first_output, second_output});
+  ASSERT_EQ(two_preds_output, first_output);
+  ASSERT_NE(two_preds_output, state_->default_output_);
 }
 
-// *****************
-// * EpsilonGreedy *
-// *****************
-
-TEST_F(PolicyTests, EpsilonGreedyTest) {
-  /* Update Test */
-  BanditPolicyState state = EpsilonGreedyPolicy::initialize(models);
-  auto feedback = Utility::create_feedback(1);
-  std::vector<Output> predictions;
-  int y_hat;
-  int rand_index;
-  int rand_draw;
-  srand(time(NULL));
-
-  for (int i = 0; i < update_times_; ++i) {
-    y_hat = 0;
-    rand_index = rand() % models.size();  // Randomly pick model
-    rand_draw = rand() % 100;  // Randomly pick number to determine whether this
-                               // model return 0 or 1
-
-    if (rand_index == 0) {  // good model
-      if (rand_draw < 75) {
-        y_hat = 1;
-      }
-    } else if (rand_index == 1) {  // so-so model
-      if (rand_draw < 50) {
-        y_hat = 1;
-      }
-    } else {
-      if (rand_draw < 25) {  // bad model
-        y_hat = 1;
-      }
-    }
-    predictions = Utility::create_predictions(models[rand_index], y_hat);
-    state = EpsilonGreedyPolicy::process_feedback(state, feedback, predictions);
-  }
-  // Test if the expected loss of model_2 > model_1 > model_0
-  ASSERT_GT(state.model_map_[model_2]["expected_loss"],
-            state.model_map_[model_1]["expected_loss"]);
-  ASSERT_GT(state.model_map_[model_1]["expected_loss"],
-            state.model_map_[model_0]["expected_loss"]);
-
-  /* Selection Test */
-  auto query = Utility::create_query(models);
-  int select_0 = 0;
-  int select_1 = 0;
-  int select_2 = 0;
-  for (int i = 0; i < select_times_; ++i) {
-    auto tasks = EpsilonGreedyPolicy::select_predict_tasks(state, query, 1000);
-    if (model_0.second == tasks.front().model_.second) {
-      select_0++;
-    } else if (model_1.second == tasks.front().model_.second) {
-      select_1++;
-    } else {
-      select_2++;
-    };
-  }
-  // Test if times selected model_0 > model_1
-  ASSERT_GT(select_0, select_1);
-
-  /* Serialization Test */
-  auto bytes = EpsilonGreedyPolicy::serialize_state(state);
-  auto new_state = EpsilonGreedyPolicy::deserialize_state(bytes);
-  ASSERT_EQ(state.weight_sum_, new_state.weight_sum_);
-}
-
-// ********
-// * UCB *
-// ********
-TEST_F(PolicyTests, UCBTest) {
-  /* Update Test */
-  BanditPolicyState state = UCBPolicy::initialize(models);
-  auto feedback = Utility::create_feedback(1);
-  std::vector<Output> predictions;
-  int y_hat;
-  int rand_index;
-  int rand_draw;
-  srand(time(NULL));
-
-  for (int i = 0; i < update_times_; ++i) {
-    y_hat = 0;
-    rand_index = rand() % models.size();  // Randomly pick model
-    rand_draw = rand() % 100;  // Randomly pick number to determine whether this
-                               // model return 0 or 1
-
-    if (rand_index == 0) {  // good model
-      if (rand_draw < 75) {
-        y_hat = 1;
-      }
-    } else if (rand_index == 1) {  // so-so model
-      if (rand_draw < 50) {
-        y_hat = 1;
-      }
-    } else {
-      if (rand_draw < 25) {  // bad model
-        y_hat = 1;
-      }
-    }
-    predictions = Utility::create_predictions(models[rand_index], y_hat);
-    state = UCBPolicy::process_feedback(state, feedback, predictions);
-  }
-  // Test if the expected loss of model_2 > model_1 > model_0
-  ASSERT_GT(state.model_map_[model_2]["expected_loss"],
-            state.model_map_[model_1]["expected_loss"]);
-  ASSERT_GT(state.model_map_[model_1]["expected_loss"],
-            state.model_map_[model_0]["expected_loss"]);
-
-  /* Selection Test */
-  auto query = Utility::create_query(models);
-  // UCB should always select the optimal bandit
-  for (int i = 0; i < select_times_; ++i) {
-    auto tasks = UCBPolicy::select_predict_tasks(state, query, 1000);
-    ASSERT_EQ(model_0.second, tasks.front().model_.second);
-  }
-
-  /* Serialization Test */
-  auto bytes = UCBPolicy::serialize_state(state);
-  auto new_state = UCBPolicy::deserialize_state(bytes);
-  ASSERT_EQ(state.weight_sum_, new_state.weight_sum_);
+TEST(DefaultOutputSelectionStateTest, Serialization) {
+  Output output{4.3, {}};
+  DefaultOutputSelectionState state{output};
+  std::string serialized_output = state.serialize();
+  DefaultOutputSelectionState deserialized_state{serialized_output};
+  ASSERT_EQ(output.y_hat_, deserialized_state.default_output_.y_hat_);
 }
 
 }  // namespace

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -185,7 +185,7 @@ class RequestHandler {
    *    {"model_name" := string, "model_version" := int}
    *  ],
    *  "input_type" := "integers" | "bytes" | "floats" | "doubles" | "strings",
-   *  "default_output" := json_string,
+   *  "default_output" := float,
    *  "latency_slo_micros" := int
    * }
    */

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -52,7 +52,7 @@ const std::string APPLICATION_JSON_SCHEMA = R"(
      {"model_name" := string, "model_version" := int}
    ],
    "input_type" := "integers" | "bytes" | "floats" | "doubles" | "strings",
-   "selection_policy" := string,
+   "default_output" := number,
    "latency_slo_micros" := int
   }
 )";

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -209,7 +209,8 @@ class RequestHandler {
     InputType input_type =
         clipper::parse_input_type(get_string(d, "input_type"));
     std::string default_output = get_string(d, "default_output");
-    std::string selection_policy = "DefaultOutputSelectionPolicy";
+    std::string selection_policy =
+        clipper::DefaultOutputSelectionPolicy::get_name();
     int latency_slo_micros = get_int(d, "latency_slo_micros");
     if (clipper::redis::add_application(
             redis_connection_, app_name, candidate_models, input_type,

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -48,10 +48,10 @@ TEST_F(ManagementFrontendTest, TestAddApplicationCorrect) {
   {
     "name": "myappname",
     "candidate_models": [
-        {"model_name": "m", "model_version": 4},
         {"model_name": "image_model", "model_version": 3}],
     "input_type": "integers",
     "selection_policy": "sample_policy",
+    "default_output": "4.3",
     "latency_slo_micros": 10000
   }
   )";
@@ -61,7 +61,7 @@ TEST_F(ManagementFrontendTest, TestAddApplicationCorrect) {
   // The application table has 5 fields, so we expect to get back a map with 5
   // entries in it (see add_application() in redis.cpp for details on what the
   // fields are).
-  ASSERT_EQ(result.size(), static_cast<size_t>(4));
+  ASSERT_EQ(result.size(), static_cast<size_t>(5));
 }
 
 TEST_F(ManagementFrontendTest, TestAddApplicationMissingField) {


### PR DESCRIPTION
Modifies query frontend and dependent infrastructure to return JSON-formatted responses to prediction queries. 

From [CLIPPER-107] and the functional spec:

> The format of the response body is a JSON object with the following fields:
> * Output (JSON key name “output”): The prediction JSON object.
> * Default used (JSON key name “default”): A boolean set to true if the model did not return in time and the default output was used. False otherwise.
>
> If there is a non-recoverable error during query execution, an error JSON object will be returned instead and the HTTP response code will be set to the most appropriate error code (a 400 or 500 error code). The format of the error is a JSON object with the following fields:
> * Error (JSON key name “error”): The name of the error.
> * Cause (JSON key name “cause”): A string describing the source of the error.

Note: This PR is currently based on the branch corresponding to #89 which has not been rebased. As a result, the diff is much larger than it should be. @dcrankshaw Rebasing #89 should make this easier to review. 