### PR TITLE
Clipper admin v2 k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Dependencies:
 pyenv virtualenv 2.7.11 clipper
 pyenv local clipper
 
-# install clipper_admin (editable)
-pip install -e .
+# install clipper_admin_v2 (editable)
+pip install -e clipper_admin_v2/.
 
 # start minikube
 minikube start --insecure-registry localhost:5000

--- a/clipper_admin_v2/clipper_admin/clipper_admin.py
+++ b/clipper_admin_v2/clipper_admin/clipper_admin.py
@@ -121,7 +121,6 @@ def deploy_model(
             tag=repo)
 
     logger.info("Pushing model Docker image to {}".format(repo))
-    print(docker_client.images.push(repository=repo))
     cm.deploy_model(name, version, input_type, repo, num_replicas=num_replicas)
     logger.info("Registering model with Clipper")
     register_model(cm, name, version, input_type, repo=repo, labels=labels)

--- a/clipper_admin_v2/clipper_admin/clipper_admin.py
+++ b/clipper_admin_v2/clipper_admin/clipper_admin.py
@@ -30,6 +30,7 @@ def register_application(cm, name, input_type, default_output, slo_micros):
     req_json = json.dumps({
         "name": name,
         "input_type": input_type,
+        "candidate_model_names": ["test"],
         "default_output": default_output,
         "latency_slo_micros": slo_micros
     })

--- a/clipper_admin_v2/clipper_admin/clipper_admin.py
+++ b/clipper_admin_v2/clipper_admin/clipper_admin.py
@@ -25,12 +25,12 @@ def start_clipper(cm):
         return False
 
 
-def register_application(cm, name, input_type, default_output, slo_micros):
+def register_application(cm, name, model_name, input_type, default_output, slo_micros):
     url = "http://{host}/admin/add_app".format(host=cm.get_admin_addr())
     req_json = json.dumps({
         "name": name,
         "input_type": input_type,
-        "candidate_model_names": ["test"],
+        "candidate_model_names": [model_name],
         "default_output": default_output,
         "latency_slo_micros": slo_micros
     })
@@ -121,7 +121,7 @@ def deploy_model(
             tag=repo)
 
     logger.info("Pushing model Docker image to {}".format(repo))
-    docker_client.images.push(repository=repo)
+    print(docker_client.images.push(repository=repo))
     cm.deploy_model(name, version, input_type, repo, num_replicas=num_replicas)
     logger.info("Registering model with Clipper")
     register_model(cm, name, version, input_type, repo=repo, labels=labels)

--- a/clipper_admin_v2/clipper_admin/container_manager.py
+++ b/clipper_admin_v2/clipper_admin/container_manager.py
@@ -2,20 +2,30 @@ import abc
 
 # Constants
 
-CLIPPER_QUERY_PORT = 1337
-CLIPPER_MANAGEMENT_PORT = 1338
-CLIPPER_RPC_PORT = 7000
-
 CLIPPER_DOCKER_LABEL = "ai.clipper.container.label"
 CLIPPER_MODEL_CONTAINER_LABEL = "ai.clipper.model_container.label"
 CONTAINERLESS_MODEL_IMAGE = "NO_CONTAINER"
 
-
 class ContainerManager(object):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, clipper_public_hostname):
+    def __init__(self,
+            clipper_public_hostname,
+            clipper_query_port=1337,
+            clipper_management_port=1338,
+            clipper_rpc_port=7000,
+            redis_ip=None,
+            redis_port=6379,
+            registry=None,
+            registry_username=None,
+            registry_password=None):
         self.public_hostname = clipper_public_hostname
+        self.clipper_query_port = clipper_query_port
+        self.clipper_management_port = clipper_management_port
+        self.clipper_rpc_port = clipper_rpc_port
+        self.redis_ip = redis_ip
+        self.redis_port = redis_port
+        self.registry = None
 
     @abc.abstractmethod
     def start_clipper(self):
@@ -80,8 +90,8 @@ class ContainerManager(object):
 
     def get_admin_addr(self):
         return "{host}:{port}".format(
-            host=self.public_hostname, port=CLIPPER_MANAGEMENT_PORT)
+            host=self.public_hostname, port=self.clipper_management_port)
 
     def get_query_addr(self):
         return "{host}:{port}".format(
-            host=self.public_hostname, port=CLIPPER_QUERY_PORT)
+            host=self.public_hostname, port=self.clipper_query_port)

--- a/clipper_admin_v2/setup.py
+++ b/clipper_admin_v2/setup.py
@@ -23,7 +23,8 @@ setup(
     keywords=['clipper', 'prediction', 'model', 'management'],
     install_requires=[
         'requests', 'pyparsing', 'appdirs', 'pprint', 'subprocess32',
-        'sklearn', 'numpy', 'scipy', 'pyyaml', 'docker', 'kubernetes', 'six'
+        'sklearn', 'numpy', 'scipy', 'pyyaml', 'docker', 'kubernetes', 'six',
+        'fabric'
     ],
     extras_require={'TensorFlow': ['tensorflow'],
                     'RPython': ['rpy2']}


### PR DESCRIPTION
 * Moves `CLIPPER_*_PORT` globals as ContainerManager instance variables (these can't be known in advance b/c they are dynamically allocated by k8s)
* Implements `deploy_model` and `get_logs` in K8sClipperManager
* Adds `model_name` argument to `register_application` (needed in the JsonSchema)