### PR TITLE
Fix for running GPU models on CPUs

### DIFF
--- a/clipper_admin/clipper_admin/docker/docker_container_manager.py
+++ b/clipper_admin/clipper_admin/docker/docker_container_manager.py
@@ -200,6 +200,10 @@ class DockerContainerManager(ContainerManager):
                 logger.info("Starting {name}:{version} on GPU {gpu_num}".format(
                     name=name, version=version, gpu_num=gpu_num))
                 env["NV_GPU"] = str(gpu_num)
+            else:
+                # We're not running on a GPU, so we should mask all available
+                # GPU resources
+                env["CUDA_VISIBLE_DEVICES"] = ""
             cmd = ["nvidia-docker", "run", "-d",
                    "--network=%s" % self.docker_network]
             for k, v in labels.iteritems():

--- a/clipper_admin/clipper_admin/docker/docker_container_manager.py
+++ b/clipper_admin/clipper_admin/docker/docker_container_manager.py
@@ -196,6 +196,8 @@ class DockerContainerManager(ContainerManager):
             # we may still need to launch it using nvidia-docker because
             # the model framework may still depend on libcuda
             env = os.environ.copy()
+            cmd = ["nvidia-docker", "run", "-d",
+                   "--network=%s" % self.docker_network]
             if gpu_num:
                 logger.info("Starting {name}:{version} on GPU {gpu_num}".format(
                     name=name, version=version, gpu_num=gpu_num))
@@ -203,9 +205,8 @@ class DockerContainerManager(ContainerManager):
             else:
                 # We're not running on a GPU, so we should mask all available
                 # GPU resources
-                env["CUDA_VISIBLE_DEVICES"] = ""
-            cmd = ["nvidia-docker", "run", "-d",
-                   "--network=%s" % self.docker_network]
+                cmd.append("-e")
+                cmd.append("CUDA_VISIBLE_DEVICES=''")
             for k, v in labels.iteritems():
                 cmd.append("-l")
                 cmd.append("%s=%s" % (k, v))

--- a/model_composition/containerized_utils/containerized_utils/driver_utils/driver_utils.py
+++ b/model_composition/containerized_utils/containerized_utils/driver_utils/driver_utils.py
@@ -17,7 +17,8 @@ class HeavyNodeConfig(object):
                  slo=500000,
                  num_replicas=1,
                  gpus=None,
-                 batch_size=1):
+                 batch_size=1,
+                 use_nvidia_docker=False)
         self.name = name
         self.input_type = input_type
         self.model_image = model_image
@@ -27,6 +28,7 @@ class HeavyNodeConfig(object):
         self.num_replicas = num_replicas
         self.gpus = gpus
         self.batch_size = batch_size
+        self.use_nvidia_docker = use_nvidia_docker
 
     def to_json(self):
         return json.dumps(self.__dict__)
@@ -46,7 +48,8 @@ def setup_heavy_node(clipper_conn, config, default_output="TIMEOUT"):
                               batch_size=config.batch_size,
                               gpus=config.gpus,
                               allocated_cpus=config.allocated_cpus,
-                              cpus_per_replica=config.cpus_per_replica)
+                              cpus_per_replica=config.cpus_per_replica,
+                              use_nvidia_docker=config.use_nvidia_docker)
 
     clipper_conn.link_model_to_app(app_name=config.name, model_name=config.name)
 

--- a/model_composition/containerized_utils/containerized_utils/driver_utils/driver_utils.py
+++ b/model_composition/containerized_utils/containerized_utils/driver_utils/driver_utils.py
@@ -18,7 +18,7 @@ class HeavyNodeConfig(object):
                  num_replicas=1,
                  gpus=None,
                  batch_size=1,
-                 use_nvidia_docker=False)
+                 use_nvidia_docker=False):
         self.name = name
         self.input_type = input_type
         self.model_image = model_image

--- a/model_composition/image_driver_1/containerized/driver.py
+++ b/model_composition/image_driver_1/containerized/driver.py
@@ -84,7 +84,8 @@ def get_heavy_node_config(model_name, batch_size, num_replicas, cpus_per_replica
                                             cpus_per_replica=cpus_per_replica,
                                             gpus=allocated_gpus,
                                             batch_size=batch_size,
-                                            num_replicas=num_replicas)
+                                            num_replicas=num_replicas,
+                                            use_nvidia_docker=True)
 
     elif model_name == INCEPTION_FEATS_MODEL_APP_NAME:
         if not cpus_per_replica:
@@ -101,7 +102,8 @@ def get_heavy_node_config(model_name, batch_size, num_replicas, cpus_per_replica
                                             cpus_per_replica=cpus_per_replica,
                                             gpus=allocated_gpus,
                                             batch_size=batch_size,
-                                            num_replicas=num_replicas)
+                                            num_replicas=num_replicas,
+                                            use_nvidia_docker=True)
 
     elif model_name == VGG_KPCA_SVM_MODEL_APP_NAME:
         if not cpus_per_replica:

--- a/model_composition/text-driver-1/containerized/driver.py
+++ b/model_composition/text-driver-1/containerized/driver.py
@@ -74,7 +74,8 @@ def get_heavy_node_config(model_name, batch_size, num_replicas, cpus_per_replica
                                             cpus_per_replica=cpus_per_replica,
                                             gpus=allocated_gpus,
                                             batch_size=batch_size,
-                                            num_replicas=num_replicas)
+                                            num_replicas=num_replicas,
+                                            use_nvidia_docker=True)
 
     elif model_name == LSTM_MODEL_APP_NAME:
         if not cpus_per_replica:
@@ -91,7 +92,8 @@ def get_heavy_node_config(model_name, batch_size, num_replicas, cpus_per_replica
                                             cpus_per_replica=cpus_per_replica,
                                             gpus=allocated_gpus,
                                             batch_size=batch_size,
-                                            num_replicas=num_replicas)
+                                            num_replicas=num_replicas,
+                                            use_nvidia_docker=True)
 
 ########## Benchmarking ##########
 


### PR DESCRIPTION
To run a GPU-supported model on a CPU, we still need to use nvidia-docker. Additionally, we need to mask all available GPU resources from the container via `CUDA_VISIBLE_DEVICES`. This PR implements that desired behavior.