### PR TITLE
(Re-) enable parallel client processes

### DIFF
--- a/model_composition/image_driver_1/containerized/README.md
+++ b/model_composition/image_driver_1/containerized/README.md
@@ -90,7 +90,9 @@ one or more of the CPU cores specified by **model_cpus**.
   * If unspecified, the set of gpus allocated depends on the specified model. You can view and modify these defaults
   [in the driver program](https://github.com/dcrankshaw/clipper/blob/4809caaccc7c6d646b19c51bcb54c6efdfa3a59c/model_composition/image_driver_1/containerized/driver.py#L70).
   * Note: This option should only be used with the Inception and VGG models, which support GPU execution.
-
+  
+- **num_clients**: The number of concurrent client processes to run. This can help increase the request rate in order to saturate high throughput models.
+  * If unspecified, this argument has a default value of `1`
 
 ### Examples
 

--- a/model_composition/image_driver_1/containerized/driver.py
+++ b/model_composition/image_driver_1/containerized/driver.py
@@ -320,7 +320,7 @@ if __name__ == "__main__":
                 benchmarker = ModelBenchmarker(model_config)
 
                 processes = []
-                for _ in range(num_clients):
+                for _ in range(args.num_clients):
                     p = Process(target=benchmarker.run, args=(args.duration,))
                     p.start()
                     processes.append(p)

--- a/model_composition/text-driver-1/containerized/README.md
+++ b/model_composition/text-driver-1/containerized/README.md
@@ -85,6 +85,9 @@ one or more of the CPU cores specified by **model_cpus**.
   * If unspecified, the set of gpus allocated depends on the specified model. You can view and modify these defaults
   [in the driver program](https://github.com/dcrankshaw/clipper/blob/4809caaccc7c6d646b19c51bcb54c6efdfa3a59c/model_composition/image_driver_1/containerized/driver.py#L70).
   * Note: This option can be used with either the LSTM or the Autocompletion model, as both support GPU execution.
+  
+- **num_clients**: The number of concurrent client processes to run. This can help increase the request rate in order to saturate high throughput models.
+  * If unspecified, this argument has a default value of `1`
 
 
 ### Examples

--- a/model_composition/text-driver-1/containerized/driver.py
+++ b/model_composition/text-driver-1/containerized/driver.py
@@ -247,7 +247,7 @@ if __name__ == "__main__":
                 benchmarker = ModelBenchmarker(model_config)
 
                 processes = []
-                for _ in range(num_clients):
+                for _ in range(args.num_clients):
                     p = Process(target=benchmarker.run, args=(args.duration,))
                     p.start()
                     processes.append(p)

--- a/model_composition/text-driver-1/containerized/driver.py
+++ b/model_composition/text-driver-1/containerized/driver.py
@@ -218,6 +218,7 @@ if __name__ == "__main__":
     parser.add_argument('-c', '--model_cpus', type=int, nargs='+', help="The set of cpu cores on which to run replicas of the provided model")
     parser.add_argument('-p', '--cpus_per_replica_nums', type=int, nargs='+', help="Configurations for the number of cpu cores allocated to each replica of the model")
     parser.add_argument('-g', '--model_gpus', type=int, nargs='+', help="The set of gpus on which to run replicas of the provided model. Each replica of a gpu model must have its own gpu!")
+    parser.add_argument('-n', '--num_clients', type=int, default=1, help="The number of concurrent client processes. This can help increase the request rate in order to saturate high throughput models.")
 
     args = parser.parse_args()
 
@@ -245,6 +246,10 @@ if __name__ == "__main__":
                 setup_clipper(model_config)
                 benchmarker = ModelBenchmarker(model_config)
 
-                p = Process(target=benchmarker.run, args=(args.duration,))
-                p.start()
-                p.join()
+                processes = []
+                for _ in range(num_clients):
+                    p = Process(target=benchmarker.run, args=(args.duration,))
+                    p.start()
+                    processes.append(p)
+                for p in processes:
+                    p.join()


### PR DESCRIPTION
Note: If you execute a driver with `n` multiple client processes, the script will produce `n` log files for the experiment.